### PR TITLE
Fix gold bars generation crash with mods adding new block states to fences

### DIFF
--- a/src/main/java/vazkii/quark/content/building/module/GoldBarsModule.java
+++ b/src/main/java/vazkii/quark/content/building/module/GoldBarsModule.java
@@ -48,6 +48,9 @@ public class GoldBarsModule extends QuarkModule {
 			if("minecraft:fortress".equals(name)) {
 				BlockState newState = gold_bars.getDefaultState();
 				for(Property prop : current.getProperties())
+					// both blocks have same properties in vanilla, so this check isn't needed,
+					// but some mods add additional block states to fences, then this would fail
+					if (newState.hasProperty(prop))
 					newState = newState.with(prop, current.get(prop));
 				return newState;
 			}


### PR DESCRIPTION
My Diagonal Fences mod adds four new block states to fences.

When Quark copies all fence block state properties to it's gold bars block during nether fortress generation the game crashes as Quark also tries to copy the block state properties added by me, without checking if they're actually supported by gold bars.

So I added a simple check when copying properties to make sure they're valid for gold bars.