### PR TITLE
Access render types through a subclass instead of ATs

### DIFF
--- a/src/main/java/vazkii/quark/content/tools/client/render/GlintRenderTypes.java
+++ b/src/main/java/vazkii/quark/content/tools/client/render/GlintRenderTypes.java
@@ -19,8 +19,12 @@ import vazkii.quark.base.Quark;
 import vazkii.quark.content.tools.module.ColorRunesModule;
 
 @OnlyIn(Dist.CLIENT)
-public class GlintRenderTypes {
-	
+public class GlintRenderTypes extends RenderType {
+    private GlintRenderTypes(String name, VertexFormat vf, VertexFormat.Mode mode, int bufSize, boolean affectsCrumbling, boolean sortOnUpload, Runnable setup, Runnable clean) {
+        super(name, vf, mode, bufSize, affectsCrumbling, sortOnUpload, setup, clean);
+        throw new UnsupportedOperationException("Don't instantiate this");
+    }
+
     public static List<RenderType> glint = newRenderList(GlintRenderTypes::buildGlintRenderType);
     public static List<RenderType> glintTranslucent = newRenderList(GlintRenderTypes::buildGlintTranslucentRenderType);
     public static List<RenderType> entityGlint = newRenderList(GlintRenderTypes::buildEntityGlintRenderType);

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -14,21 +14,6 @@ public net.minecraft.client.gui.screens.recipebook.RecipeBookPage f_100399_ # re
 public net.minecraft.client.multiplayer.PlayerInfo f_105299_ # playerTextures
 public net.minecraft.client.player.AbstractClientPlayer f_108546_ # playerInfo
 public net.minecraft.client.renderer.LevelRenderer f_109410_ # mapSoundPositions
-public net.minecraft.client.renderer.RenderStateShard f_110110_ # CULL_DISABLED
-public net.minecraft.client.renderer.RenderStateShard f_110112_ # DEPTH_EQUAL
-public net.minecraft.client.renderer.RenderStateShard f_110115_ # COLOR_WRITE
-public net.minecraft.client.renderer.RenderStateShard f_110119_ # VIEW_OFFSET_Z_LAYER
-public net.minecraft.client.renderer.RenderStateShard f_110129_ # ITEM_ENTITY_TARGET
-public net.minecraft.client.renderer.RenderStateShard f_110137_ # GLINT_TRANSPARENCY
-public net.minecraft.client.renderer.RenderStateShard f_110150_ # GLINT_TEXTURING
-public net.minecraft.client.renderer.RenderStateShard f_110151_ # ENTITY_GLINT_TEXTURING
-public net.minecraft.client.renderer.RenderStateShard f_173078_ # RENDERTYPE_ARMOR_GLINT_SHADER
-public net.minecraft.client.renderer.RenderStateShard f_173079_ # RENDERTYPE_ARMOR_ENTITY_GLINT_SHADER
-public net.minecraft.client.renderer.RenderStateShard f_173080_ # RENDERTYPE_GLINT_TRANSLUCENT_SHADER
-public net.minecraft.client.renderer.RenderStateShard f_173081_ # RENDERTYPE_GLINT_SHADER
-public net.minecraft.client.renderer.RenderStateShard f_173082_ # RENDERTYPE_GLINT_DIRECT_SHADER
-public net.minecraft.client.renderer.RenderStateShard f_173083_ # RENDERTYPE_ENTITY_GLINT_SHADER
-public net.minecraft.client.renderer.RenderStateShard f_173084_ # RENDERTYPE_ENTITY_GLINT_DIRECT_SHADER
 public net.minecraft.client.renderer.entity.EntityRenderers f_174031_ # PROVIDERS
 public net.minecraft.client.renderer.entity.LivingEntityRenderer f_115291_ # layerRenderers
 public net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer m_117078_(Lnet/minecraft/world/entity/EquipmentSlot;)Lnet/minecraft/client/model/HumanoidModel; #func_241736_a_


### PR DESCRIPTION
Resolves #3503. This is the only thing that prevents the missing dependency screen from showing up, luckily enough.