### PR TITLE
More chest reversions

### DIFF
--- a/src/main/resources/data/quark/recipes/building/crafting/chests/chest_trapped.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/chests/chest_trapped.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:chest"
+    },
+    {
+      "item": "minecraft:tripwire_hook"
+    }
+  ],
+  "result": {
+    "item": "minecraft:trapped_chest"
+  },
+  "conditions": [
+    {
+      "type": "quark:flag",
+      "flag": "variant_chests"
+    }
+  ]
+}

--- a/src/main/resources/data/quark/recipes/building/crafting/chests/trapped_chest_revert.json
+++ b/src/main/resources/data/quark/recipes/building/crafting/chests/trapped_chest_revert.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "quark:revertable_trapped_chests"
+    }
+  ],
+  "result": {
+    "item": "minecraft:trapped_chest"
+  },
+  "conditions": [
+    {
+      "type": "quark:flag",
+      "flag": "chest_reversion"
+    }
+  ]
+}

--- a/src/main/resources/data/quark/tags/items/revertable_chests.json
+++ b/src/main/resources/data/quark/tags/items/revertable_chests.json
@@ -1,13 +1,15 @@
 {
   "replace": false,
   "values": [
-    "quark:oak_chest",
+	"quark:oak_chest",
 	"quark:spruce_chest",
 	"quark:birch_chest",
 	"quark:jungle_chest",
 	"quark:acacia_chest",
 	"quark:dark_oak_chest",
 	"quark:warped_chest",
-	"quark:crimson_chest"
+	"quark:crimson_chest",
+	"quark:azalea_chest",
+	"quark:blossom_chest"
   ]
 }

--- a/src/main/resources/data/quark/tags/items/revertable_trapped_chests.json
+++ b/src/main/resources/data/quark/tags/items/revertable_trapped_chests.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "values": [
+	"quark:oak_trapped_chest",
+	"quark:spruce_trapped_chest",
+	"quark:birch_trapped_chest",
+	"quark:jungle_trapped_chest",
+	"quark:acacia_trapped_chest",
+	"quark:dark_oak_trapped_chest",
+	"quark:warped_trapped_chest",
+	"quark:crimson_trapped_chest",
+	"quark:azalea_trapped_chest",
+	"quark:blossom_trapped_chest"
+  ]
+}


### PR DESCRIPTION
Adds the new blossom and azalea chests to the revertable chests tag.

Also creates a new tag and recipe for reverting trapped chests, and adds a version of the vanilla trapped chest recipe, making vanilla trapped chests craftable again!

Nya,