### PR TITLE
Changed position of emote button [Quality of life improvment]

### DIFF
--- a/src/main/java/vazkii/quark/content/tweaks/module/EmotesModule.java
+++ b/src/main/java/vazkii/quark/content/tweaks/module/EmotesModule.java
@@ -193,7 +193,7 @@ public class EmotesModule extends QuarkModule {
 				}
 			}
 
-			int buttonY = (expandDown ? 2 : gui.height - 40);
+			int buttonY = (expandDown ? 2 : gui.height - 37);
 
 			List<Button> emoteButtons = new LinkedList<>();
 			for (int tier : keys) {
@@ -204,7 +204,7 @@ public class EmotesModule extends QuarkModule {
 					for (EmoteDescriptor desc : descriptors) {
 						int rowSize = Math.min(descriptors.size() - tierRow * EMOTES_PER_ROW, EMOTES_PER_ROW);
 
-						int x = gui.width - (EMOTE_BUTTON_WIDTH * (EMOTES_PER_ROW + 1)) + (((rowPos + 1) * 2 + EMOTES_PER_ROW - rowSize) * EMOTE_BUTTON_WIDTH / 2 + 1);
+						int x = gui.width - 51 - (EMOTE_BUTTON_WIDTH * (EMOTES_PER_ROW + 1)) + (((rowPos + 1) * 2 + EMOTES_PER_ROW - rowSize) * EMOTE_BUTTON_WIDTH / 2 + 1);
 						int y = buttonY + (EMOTE_BUTTON_WIDTH * (rows - row)) * (expandDown ? 1 : -1);
 
 						Button button = new EmoteButton(x, y, desc, (b) -> {
@@ -228,7 +228,7 @@ public class EmotesModule extends QuarkModule {
 					row++;
 			}
 
-			event.addListener(new TranslucentButton(gui.width - 1 - EMOTE_BUTTON_WIDTH * EMOTES_PER_ROW, buttonY, EMOTE_BUTTON_WIDTH * EMOTES_PER_ROW, 20,
+			event.addListener(new TranslucentButton(gui.width - 50 - EMOTE_BUTTON_WIDTH * EMOTES_PER_ROW, buttonY, EMOTE_BUTTON_WIDTH * EMOTES_PER_ROW, 20,
 					Component.translatable("quark.gui.button.emotes"),
 					(b) -> {
 						for(Button bt : emoteButtons)


### PR DESCRIPTION
Hi, so recently I started to make a small modpack.
I noticed that some mods are using the same position when opening the chat and got overlayed.
One of the mods was quark with its Emotes button.
Not only this, but also the emotes button from quark is a little higher,
than the other buttons.
> Picture1: (https://i.imgur.com/fdl2esH.png)

Also what I noticed, that the emotes menu is inline of the button.
> Picture2: (https://i.imgur.com/Va4342H.png)

With my pull request I fix all three problems.
I tested everything, and everything works like before.
> Picture3: (https://i.imgur.com/gqTZvax.png)

Here are also the logs: https://pastebin.com/Qv1GgxP4