### PR TITLE
wip: Clean up Ancient Tree, attempt to register

### DIFF
--- a/src/main/java/vazkii/quark/content/world/block/AncientSaplingBlock.java
+++ b/src/main/java/vazkii/quark/content/world/block/AncientSaplingBlock.java
@@ -1,9 +1,6 @@
 package vazkii.quark.content.world.block;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -12,12 +9,18 @@ import javax.annotation.Nonnull;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.Vec3i;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.valueproviders.ConstantInt;
+import net.minecraft.util.valueproviders.IntProvider;
 import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.level.LevelSimulatedReader;
+import net.minecraft.world.level.block.LeavesBlock;
 import net.minecraft.world.level.block.grower.AbstractTreeGrower;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
@@ -31,6 +34,8 @@ import net.minecraft.world.level.levelgen.feature.treedecorators.TreeDecorator;
 import net.minecraft.world.level.levelgen.feature.treedecorators.TreeDecoratorType;
 import net.minecraft.world.level.levelgen.feature.trunkplacers.TrunkPlacer;
 import net.minecraft.world.level.levelgen.feature.trunkplacers.TrunkPlacerType;
+import org.jetbrains.annotations.NotNull;
+import vazkii.arl.util.RegistryHelper;
 import vazkii.quark.base.block.QuarkSaplingBlock;
 import vazkii.quark.base.module.QuarkModule;
 import vazkii.quark.content.world.module.AncientWoodModule;
@@ -48,69 +53,104 @@ public class AncientSaplingBlock extends QuarkSaplingBlock {
 		public AncientTree() {
 			config = (new TreeConfiguration.TreeConfigurationBuilder(
 					BlockStateProvider.simple(AncientWoodModule.woodSet.log),
-					new MultiFolliageStraightTrunkPlacer(17, 4, 6, 5, 3),
+					new MultiFoliageStraightTrunkPlacer(17, 4, 6, ConstantInt.of(5), ConstantInt.of(3), ConstantInt.of(3)),
 					BlockStateProvider.simple(AncientWoodModule.ancient_leaves),
-					new FancyFoliagePlacer(UniformInt.of(2, 4), ConstantInt.of(-3) , 2),
+					new FancyFoliagePlacer(UniformInt.of(2, 4), ConstantInt.of(0) , 2),
 					new TwoLayersFeatureSize(0, 0, 0, OptionalInt.of(4))))
-					.decorators(Lists.newArrayList(new AncientTreeTopperDecorator()))
+					.decorators(Lists.newArrayList(new AncientTreeTopperDecorator(
+						BlockStateProvider.simple(AncientWoodModule.ancient_leaves.defaultBlockState().setValue(LeavesBlock.DISTANCE, 1))))
+					)
 					.ignoreVines()
 					.build();
 		}
 
 		@Override
-		protected Holder<ConfiguredFeature<TreeConfiguration, ?>> getConfiguredFeature(@Nonnull RandomSource rand, boolean hjskfsd) {
+		protected Holder<ConfiguredFeature<TreeConfiguration, ?>> getConfiguredFeature(@Nonnull RandomSource rand, boolean beehive) {
 			return Holder.direct(new ConfiguredFeature<>(Feature.TREE, config));
 		}
 
 	}
 	
-	public static class MultiFolliageStraightTrunkPlacer extends TrunkPlacer {
+	public static class MultiFoliageStraightTrunkPlacer extends TrunkPlacer {
 
-		final int folliageDistance;
-		final int maxBlobs;
+		private final IntProvider foliageDistance;
+		private final IntProvider maxBlobs;
+		private final IntProvider freeTopHeight;
 		
-		public MultiFolliageStraightTrunkPlacer(int baseHeight, int heightRandA, int heightRandB, int folliageDistance, int maxBlobs) {
+		public MultiFoliageStraightTrunkPlacer(int baseHeight, int heightRandA, int heightRandB, IntProvider foliageDistance, IntProvider maxBlobs, IntProvider freeTopHeight) {
 			super(baseHeight, heightRandA, heightRandB);
-			this.folliageDistance = folliageDistance;
+			this.foliageDistance = foliageDistance;
 			this.maxBlobs = maxBlobs;
+			this.freeTopHeight = freeTopHeight;
 		}
 
 		@Override
-		public List<FoliagePlacer.FoliageAttachment> placeTrunk(LevelSimulatedReader p_226147_, BiConsumer<BlockPos, BlockState> p_226148_, RandomSource p_226149_, int p_226150_, BlockPos p_226151_, TreeConfiguration p_226152_) {
-			setDirtAt(p_226147_, p_226148_, p_226149_, p_226151_.below(), p_226152_);
+		public List<FoliagePlacer.FoliageAttachment> placeTrunk(LevelSimulatedReader level, BiConsumer<BlockPos, BlockState> blockSetter, RandomSource random, int freeTreeHeight, BlockPos pos, TreeConfiguration config) {
+			setDirtAt(level, blockSetter, random, pos.below(), config);
 
-			List<BlockPos> folliagePositions = new ArrayList<>();
-			
+			List<BlockPos> foliagePositions = new ArrayList<>();
+
+			int sampledMaxBlobs = maxBlobs.sample(random);
 			int placed = 0;
-			int j = 0;
-			for(int i = p_226150_; i >= 0; --i) {
-				BlockPos target = p_226151_.above(i);
-				this.placeLog(p_226147_, p_226148_, p_226149_, target, p_226152_);
+			int j = freeTopHeight.sample(random);
+			for(int i = freeTreeHeight; i >= 0; --i) {
+				BlockPos target = pos.above(i);
+				this.placeLog(level, blockSetter, random, target, config);
 				
-				if(placed < maxBlobs) {
+				if(placed < sampledMaxBlobs) {
 					if(j == 0) {
-						folliagePositions.add(target);
-						j = folliageDistance;
+						foliagePositions.add(target);
+						j = foliageDistance.sample(random);
 						placed++;
 					} else j--;
 				}
 				
 			}
 
-			return folliagePositions.stream().map(p -> new FoliagePlacer.FoliageAttachment(p, 0, false)).collect(Collectors.toList());
+			return foliagePositions.stream().map(p -> new FoliagePlacer.FoliageAttachment(p, 0, false)).collect(Collectors.toList());
 		}
 
 		@Override
 		protected TrunkPlacerType<?> type() {
-			return null;
+			return Type.ANCIENT_TREE_TOPPER;
+		}
+
+		public static class Type extends TrunkPlacerType<MultiFoliageStraightTrunkPlacer> {
+			public static final TrunkPlacerType<MultiFoliageStraightTrunkPlacer> ANCIENT_TREE_TOPPER = register();
+
+			private static final Codec<MultiFoliageStraightTrunkPlacer> CODEC = RecordCodecBuilder.create(
+				instance -> trunkPlacerParts(instance)
+					.and(IntProvider.NON_NEGATIVE_CODEC.fieldOf("foliage_distance").forGetter(trunkPlacer -> trunkPlacer.foliageDistance))
+					.and(IntProvider.NON_NEGATIVE_CODEC.fieldOf("max_blobs").forGetter(trunkPlacer -> trunkPlacer.maxBlobs))
+					.and(IntProvider.NON_NEGATIVE_CODEC.fieldOf("free_top_height").forGetter(trunkPlacer -> trunkPlacer.freeTopHeight))
+					.apply(instance, MultiFoliageStraightTrunkPlacer::new)
+			);
+
+			private static TrunkPlacerType<MultiFoliageStraightTrunkPlacer> register() {
+				Type t = new Type();
+				RegistryHelper.register(t, "multi_foliage_straight_trunk_placer", Registry.TRUNK_PLACER_TYPE_REGISTRY);
+				return t;
+			}
+
+			public static void init() {}
+
+			private Type() {
+				super(CODEC);
+			}
 		}
 	}
 	
 	public static class AncientTreeTopperDecorator extends TreeDecorator {
 
+		private final BlockStateProvider foliageProvider;
+
+		public AncientTreeTopperDecorator(BlockStateProvider foliageProvider) {
+			this.foliageProvider = foliageProvider;
+		}
+
 		@Override
 		public void place(Context ctx) {
-			Optional<BlockPos> pos = ctx.logs().stream().max((a, b) -> a.getY() - b.getY());
+			Optional<BlockPos> pos = ctx.logs().stream().max(Comparator.comparingInt(Vec3i::getY));
 			if(pos.isPresent()) {
 				BlockPos top = pos.get();
 				
@@ -118,19 +158,39 @@ public class AncientSaplingBlock extends QuarkSaplingBlock {
 						top.above(), top.east(), top.west(), top.north(), top.south()
 				);
 				
-				BlockState state = AncientWoodModule.ancient_leaves.defaultBlockState();
 				leafPos.forEach(p -> {
 					if(ctx.isAir(p))
-						ctx.setBlock(p, state);
+						ctx.setBlock(p, foliageProvider.getState(ctx.random(), p));
 				});
 			}
 		}
 		
 		@Override
-		protected TreeDecoratorType<?> type() {
-			return null;
+		protected @NotNull TreeDecoratorType<?> type() {
+			return Type.ANCIENT_TREE_TOPPER;
 		}
 
+		public static class Type extends TreeDecoratorType<AncientTreeTopperDecorator> {
+			public static final TreeDecoratorType<AncientTreeTopperDecorator> ANCIENT_TREE_TOPPER = register();
+
+			private static final Codec<AncientTreeTopperDecorator> CODEC = RecordCodecBuilder.create(
+				instance -> instance.group(
+					BlockStateProvider.CODEC.fieldOf("foliage_provider").forGetter(decorator -> decorator.foliageProvider)
+				).apply(instance, AncientTreeTopperDecorator::new)
+			);
+
+			private static TreeDecoratorType<AncientTreeTopperDecorator> register() {
+				Type t = new Type();
+				RegistryHelper.register(t, "ancient_tree_topper", Registry.TREE_DECORATOR_TYPE_REGISTRY);
+				return t;
+			}
+
+			public static void init() {}
+
+			private Type() {
+				super(CODEC);
+			}
+		}
 		
 	}
 

--- a/src/main/java/vazkii/quark/content/world/module/AncientWoodModule.java
+++ b/src/main/java/vazkii/quark/content/world/module/AncientWoodModule.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProvider;
 import net.minecraft.world.level.material.MaterialColor;
 import net.minecraft.world.level.storage.loot.BuiltInLootTables;
 import net.minecraft.world.level.storage.loot.entries.LootItem;
@@ -59,6 +60,9 @@ public class AncientWoodModule extends QuarkModule {
 		ancient_leaves = new QuarkLeavesBlock(woodSet.name, this, MaterialColor.PLANT);
 		ancient_sapling = new AncientSaplingBlock(this);
 		ancient_fruit = new AncientFruitItem(this);
+
+		AncientSaplingBlock.MultiFoliageStraightTrunkPlacer.Type.init();
+		AncientSaplingBlock.AncientTreeTopperDecorator.Type.init();
 
 		VariantHandler.addFlowerPot(ancient_sapling, RegistryHelper.getInternalName(ancient_sapling).getPath(), Functions.identity());
 		


### PR DESCRIPTION
This cleans up the tree code a bit as well as adding codecs for the custom trunk placer and tree decorator

For some reason they're not actually being registered, even though i've checked with a breakpoint the register method does get called. But datapacks still say they can't find the trunk placer `quark:multi_foliage_straight_trunk_placer`. Maybe you know what could be wrong since you made ARL.

We could also try actually making a dedicated `QuarkTrunkPlacerType` class that works more like vanilla's instead of making a specific class for just the one type. Maybe something's wrong with how i implemented the `Type` classes. This would also make the trunk placer type available to datapacks even if the ancient wood module is disabled.