### PR TITLE
Fix config GUI buttons taking click priority over footer buttons

### DIFF
--- a/src/main/java/vazkii/quark/base/client/config/screen/AbstractScrollingWidgetScreen.java
+++ b/src/main/java/vazkii/quark/base/client/config/screen/AbstractScrollingWidgetScreen.java
@@ -33,11 +33,6 @@ public abstract class AbstractScrollingWidgetScreen extends AbstractQScreen {
 	protected void init() {
 		super.init();
 
-		elementList = createWidgetList();
-		addWidget(elementList);
-		refresh();
-		needsScrollUpdate = true;
-
 		int pad = 3;
 		int bWidth = 121;
 		int left = (width - (bWidth + pad) * 3) / 2;
@@ -46,6 +41,11 @@ public abstract class AbstractScrollingWidgetScreen extends AbstractQScreen {
 		addRenderableWidget(new Button(left, vStart, bWidth, 20, Component.translatable("quark.gui.config.default"), this::onClickDefault));
 		addRenderableWidget(resetButton = new Button(left + bWidth + pad, vStart, bWidth, 20, Component.translatable("quark.gui.config.discard"), this::onClickDiscard));
 		addRenderableWidget(new Button(left + (bWidth + pad) * 2, vStart, bWidth, 20, Component.translatable("gui.done"), this::onClickDone));
+
+		elementList = createWidgetList();
+		addWidget(elementList);
+		refresh();
+		needsScrollUpdate = true;
 	}
 
 	@Override


### PR DESCRIPTION
If you click here, it counts as clicking the barely-visible config button, instead of the "done" button:

![java_XHahoYesgl](https://user-images.githubusercontent.com/2068021/214991804-48156a84-1356-435a-b74d-0d7416ff9693.png)

This PR changes footer buttons to be registered first, so they win. This incidentally also changes the tab index (you now visit the footer first when pressing Tab)