### PR TITLE
Change pistons to not construct extra block entities

### DIFF
--- a/src/main/java/vazkii/quark/content/automation/client/render/QuarkPistonBlockEntityRenderer.java
+++ b/src/main/java/vazkii/quark/content/automation/client/render/QuarkPistonBlockEntityRenderer.java
@@ -9,14 +9,19 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.piston.PistonMovingBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.registries.ForgeRegistries;
 import vazkii.quark.base.Quark;
 import vazkii.quark.content.automation.module.PistonsMoveTileEntitiesModule;
 
@@ -28,9 +33,13 @@ public class QuarkPistonBlockEntityRenderer {
 
 		BlockState state = piston.getMovedState();
 		BlockPos truePos = piston.getBlockPos();
-		BlockEntity tile = PistonsMoveTileEntitiesModule.getMovement(piston.getLevel(), truePos);
+		if (!(state.getBlock() instanceof EntityBlock eb)) return false;
+		BlockEntity tile = eb.newBlockEntity(truePos, state);
+		if (tile == null) return false;
+		CompoundTag tileTag = PistonsMoveTileEntitiesModule.getMovement(piston.getLevel(), truePos);
+		if (tileTag != null && tile.getType() == ForgeRegistries.BLOCK_ENTITY_TYPES.getValue(new ResourceLocation(tileTag.getString("id"))))
+			tile.load(tileTag);
 		Vec3 offset = new Vec3(piston.getXOff(partialTicks), piston.getYOff(partialTicks), piston.getZOff(partialTicks));
-		
 		return renderTESafely(piston.getLevel(), truePos, state, tile, piston, partialTicks, offset, matrix, bufferIn, combinedLightIn, combinedOverlayIn);
 	}
 	


### PR DESCRIPTION
This fixes an issue with (at least) AE2 that's caused by creating a new block entity instead of loading the data into the one created by vanilla when the block state is set in the world.

This incidentally slightly changes the semantics of the IPistonCallback onPistonMovementFinished method, causing it to be called on the block entity that is in the world [after the data has been loaded into it] instead of on a fresh block entity that will be replacing the one that's in the world.