### PR TITLE
Questionable Ancient Tomes changes.

### DIFF
--- a/src/main/java/vazkii/quark/content/tools/module/AncientTomesModule.java
+++ b/src/main/java/vazkii/quark/content/tools/module/AncientTomesModule.java
@@ -209,7 +209,7 @@ public class AncientTomesModule extends QuarkModule {
 		String name = event.getName();
 
 		if(!left.isEmpty() && !right.isEmpty() ) {
-			if(right.is(ancient_tome)) {
+			if(!left.is(ENCHANTED_BOOK) && right.is(ancient_tome)) {
 				Enchantment ench = getTomeEnchantment(right);
 				Map<Enchantment, Integer> enchants = EnchantmentHelper.getEnchantments(left);
 
@@ -231,7 +231,7 @@ public class AncientTomesModule extends QuarkModule {
 				}
 			}
 
-			else if(combineWithBooks && right.is(Items.ENCHANTED_BOOK)) {
+			else if(combineWithBooks && left.is(Items.ENCHANTED_BOOK) && right.is(ancient_tome)) {
 				Map<Enchantment, Integer> enchants = EnchantmentHelper.getEnchantments(right);
 				Map<Enchantment, Integer> currentEnchants = EnchantmentHelper.getEnchantments(left);
 				boolean hasOverLevel = false;


### PR DESCRIPTION
Attemnt to fix Ancient Tomes feature to disable combining with enchanting books on toggle. For now it is not taking affect, since it falls under first IF case.