### PR TITLE
Clarify wording in forgotten spawn rate config description

### DIFF
--- a/src/main/java/vazkii/quark/content/mobs/module/ForgottenModule.java
+++ b/src/main/java/vazkii/quark/content/mobs/module/ForgottenModule.java
@@ -41,7 +41,7 @@ public class ForgottenModule extends QuarkModule {
 
 	@Hint public static Item forgotten_hat;
 
-	@Config(description = "1 in this many Skeletons that spawn under the threshold are replaced with Forgotten.")
+	@Config(description = "This is the probability of a Skeleton that spawns under the height threshold being replaced with a Forgotten.")
 	public double forgottenSpawnRate = 0.05;
 
 	@Config public int maxHeightForSpawn = 0;


### PR DESCRIPTION
The current wording of the config description is wrong: it says that 1/forgottenSpwanRate skeletons will be transformed into a forgotten, but the actual value is simply forgottenSpwanRate.