### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/src/main/java/vazkii/quark/content/tools/module/PathfinderMapsModule.java
+++ b/src/main/java/vazkii/quark/content/tools/module/PathfinderMapsModule.java
@@ -80,7 +80,7 @@ public class PathfinderMapsModule extends QuarkModule {
 			<id>,<level>,<min_price>,<max_price>,<color>,<name>
 
 			With the following descriptions:
-			 - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.gamepedia.com/Biome#Biome_IDs
+			 - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.wiki/w/Biome#Biome_IDs
 			 - <level> being the Cartographer villager level required for the map to be unlockable
 			 - <min_price> being the cheapest (in Emeralds) the map can be
 			 - <max_price> being the most expensive (in Emeralds) the map can be


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.