### PR TITLE
Update non-Block Leather Recipes to Use forge:leather

### DIFF
--- a/src/main/resources/data/quark/recipes/oddities/crafting/backpack.json
+++ b/src/main/resources/data/quark/recipes/oddities/crafting/backpack.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "L": {
-      "item": "minecraft:leather"
+      "tag": "forge:leather"
     },
     "R": {
       "item": "quark:ravager_hide"

--- a/src/main/resources/data/quark/recipes/oddities/crafting/backpack_no_hide.json
+++ b/src/main/resources/data/quark/recipes/oddities/crafting/backpack_no_hide.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "L": {
-      "item": "minecraft:leather"
+      "tag": "forge:leather"
     },
     "C": {
       "tag": "forge:chests/wooden"

--- a/src/main/resources/data/quark/recipes/tools/crafting/bundle.json
+++ b/src/main/resources/data/quark/recipes/tools/crafting/bundle.json
@@ -10,7 +10,7 @@
       "item": "minecraft:string"
     },
     "H": {
-      "item": "minecraft:leather"
+      "tag": "forge:leather"
     }
   },
   "result": {

--- a/src/main/resources/data/quark/recipes/tools/crafting/seed_pouch.json
+++ b/src/main/resources/data/quark/recipes/tools/crafting/seed_pouch.json
@@ -13,7 +13,7 @@
       "tag": "quark:seed_pouch_holdable"
     },
     "H": {
-      "item": "minecraft:leather"
+      "tag": "forge:leather"
     }
   },
   "result": {


### PR DESCRIPTION
This is primarily for compat with Immersive Engineering and other mods which add non-Minecraft leather to the Forge tag. IE Ersatz Leather can be used in the place of leather but should not be bundled into bonded leather, hence the non-Bonded Leather recipes changing.

If there was datagen I needed to update, I could not manage to find it.