### PR TITLE
Make top buttons be in the top right on containers that doesn't use full chest rows

### DIFF
--- a/src/main/java/org/violetmoon/quark/content/client/module/ChestSearchingModule.java
+++ b/src/main/java/org/violetmoon/quark/content/client/module/ChestSearchingModule.java
@@ -88,7 +88,7 @@ public class ChestSearchingModule extends ZetaModule {
 
 		@LoadEvent
 		public final void clientSetup(ZClientSetup event) {
-			InventoryButtonHandler.addButtonProvider(this, ButtonTargetType.CONTAINER_INVENTORY, 1, (parent, x, y) -> new MiniInventoryButton(parent, 3, x, y, "quark.gui.button.filter", (b) -> {
+			InventoryButtonHandler.addButtonProvider(this, ButtonTargetType.CONTAINER_INVENTORY, 1, (parent, x, y) -> new MiniInventoryButton(parent, 3, parent.getXSize() - 30, 5, "quark.gui.button.filter", (b) -> {
 				if(searchBar != null) {
 					searchEnabled = !searchEnabled;
 					updateSearchStatus();

--- a/src/main/java/org/violetmoon/quark/content/management/module/InventorySortingModule.java
+++ b/src/main/java/org/violetmoon/quark/content/management/module/InventorySortingModule.java
@@ -73,7 +73,7 @@ public class InventorySortingModule extends ZetaModule {
 		}
 
 		private InventoryButtonHandler.ButtonProvider provider(String tooltip, boolean forcePlayer, BooleanSupplier condition) {
-			return (parent, x, y) -> !condition.getAsBoolean() ? null : new MiniInventoryButton(parent, 0, x, y, "quark.gui.button." + tooltip, (b) -> QuarkClient.ZETA_CLIENT.sendToServer(new SortInventoryMessage(forcePlayer)));
+			return (parent, x, y) -> !condition.getAsBoolean() ? null : new MiniInventoryButton(parent, 0, tooltip.equals("sort_container") ? parent.getXSize() - 18 : x, tooltip.equals("sort_container") ? 5 : y, "quark.gui.button." + tooltip, (b) -> QuarkClient.ZETA_CLIENT.sendToServer(new SortInventoryMessage(forcePlayer)));
 		}
 
 		private void click() {


### PR DESCRIPTION
Containers that don't use the same length for rows as chests have the filter & sort chest buttons in the middle of them, things like Supplementaries sacks, TFC's vessels, donkeys with chests, etc
This also doesn't change the normal containers, like chests

![chest_buttons](https://github.com/VazkiiMods/Quark/assets/11804768/3f69b484-0397-495e-9349-9ddeae216d84)
