### PR TITLE
Add Bumblezone's special items to Quark's enchanting tooltip config

### DIFF
--- a/src/main/java/org/violetmoon/quark/content/client/module/ImprovedTooltipsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/client/module/ImprovedTooltipsModule.java
@@ -79,7 +79,8 @@ public class ImprovedTooltipsModule extends ZetaModule {
 	public static List<String> enchantingStacks = Lists.newArrayList("minecraft:diamond_sword", "minecraft:diamond_pickaxe", "minecraft:diamond_shovel", "minecraft:diamond_axe", "minecraft:diamond_hoe",
 			"minecraft:diamond_helmet", "minecraft:diamond_chestplate", "minecraft:diamond_leggings", "minecraft:diamond_boots",
 			"minecraft:shears", "minecraft:bow", "minecraft:fishing_rod", "minecraft:crossbow", "minecraft:trident", "minecraft:elytra", "minecraft:shield",
-			"quark:pickarang", "supplementaries:slingshot", "supplementaries:bubble_blower", "farmersdelight:diamond_knife");
+			"quark:pickarang", "supplementaries:slingshot", "supplementaries:bubble_blower", "farmersdelight:diamond_knife", "the_bumblezone:stinger_spear", 
+			"the_bumblezone:crystal_cannon", "the_bumblezone:honey_crystal_shield", "the_bumblezone:honey_bee_leggings_2");
 
 	@Config(
 		description = "A list of additional stacks to display on each enchantment\n"


### PR DESCRIPTION
These items from Bumblezone disallows and allows a more unique combination of enchantments than normal equivalent items. Having them show in enchantment tooltip would be useful for users.

I am removing my code compat that was injecting these items into Quark's tooltip list of items before in favor of adding directly to Quark's config
https://github.com/TelepathicGrunt/Bumblezone/issues/354