### PR TITLE
Fix llegalArgumentException when spawning wraith without valid sounds

### DIFF
--- a/src/main/java/vazkii/quark/content/mobs/entity/Wraith.java
+++ b/src/main/java/vazkii/quark/content/mobs/entity/Wraith.java
@@ -129,7 +129,7 @@ public class Wraith extends Zombie {
 	public SpawnGroupData finalizeSpawn(@Nonnull ServerLevelAccessor worldIn, @Nonnull DifficultyInstance difficultyIn, @Nonnull MobSpawnType reason, SpawnGroupData spawnDataIn, CompoundTag dataTag) {
 		int wraithSoundsSize = WraithModule.validWraithSounds.size();
 		if(wraithSoundsSize > 0) {
-			int idx = random.nextInt(WraithModule.validWraithSounds.size());
+			int idx = random.nextInt(wraithSoundsSize);
 			String sound = WraithModule.validWraithSounds.get(idx);
 			String[] split = sound.split("\\|");
 	

--- a/src/main/java/vazkii/quark/content/mobs/entity/Wraith.java
+++ b/src/main/java/vazkii/quark/content/mobs/entity/Wraith.java
@@ -127,13 +127,16 @@ public class Wraith extends Zombie {
 
 	@Override
 	public SpawnGroupData finalizeSpawn(@Nonnull ServerLevelAccessor worldIn, @Nonnull DifficultyInstance difficultyIn, @Nonnull MobSpawnType reason, SpawnGroupData spawnDataIn, CompoundTag dataTag) {
-		int idx = random.nextInt(WraithModule.validWraithSounds.size());
-		String sound = WraithModule.validWraithSounds.get(idx);
-		String[] split = sound.split("\\|");
-
-		entityData.set(IDLE_SOUND, split[0]);
-		entityData.set(HURT_SOUND, split[1]);
-		entityData.set(DEATH_SOUND, split[2]);
+		int wraithSoundsSize = WraithModule.validWraithSounds.size();
+		if(wraithSoundsSize > 0) {
+			int idx = random.nextInt(WraithModule.validWraithSounds.size());
+			String sound = WraithModule.validWraithSounds.get(idx);
+			String[] split = sound.split("\\|");
+	
+			entityData.set(IDLE_SOUND, split[0]);
+			entityData.set(HURT_SOUND, split[1]);
+			entityData.set(DEATH_SOUND, split[2]);
+		}
 
 		return super.finalizeSpawn(worldIn, difficultyIn, reason, spawnDataIn, dataTag);
 	}


### PR DESCRIPTION
Crash report

```
Description: Exception ticking world

java.lang.IllegalArgumentException: bound must be positive
        at java.util.Random.nextInt(Random.java:322) ~[?:?] {re:mixin}
        at vazkii.quark.content.mobs.entity.Wraith.m_6518_(Wraith.java:130) ~[Quark-3.2-358.jar%23191!/:3.2-358] {re:classloading}
        at net.minecraft.world.level.NaturalSpawner.m_47038_(NaturalSpawner.java:186) ~[server-1.18.2-20220404.173914-srg.jar%23232!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:servercore.common.mixins.json:optimizations.tickets.NaturalSpawnerMixin,pl:mixin:A}
[etc]
```

I believe this happens because, with the hope of making wraiths shut up forever, I removed all sounds from the config.

THIS FIX WAS NOT TESTED. I just changed the code so that `nextInt` is not called with an invalid argument.