### PR TITLE
Remove duplicate `cherry_vertical_slab` key

### DIFF
--- a/src/main/resources/assets/quark/lang/en_us.json
+++ b/src/main/resources/assets/quark/lang/en_us.json
@@ -1329,7 +1329,6 @@
 	"block.quark.carved_mud_bricks": "Carved Mud Bricks",
 	"block.quark.mud_brick_lattice": "Mud Brick Lattice",
 	"block.quark.mud_pillar": "Mud Pillar",
-	"block.quark.cherry_vertical_slab": "Cherry Vertical Slab",
 	"block.quark.bamboo_vertical_slab": "Bamboo Vertical Slab",
 	"block.quark.bamboo_mosaic_vertical_slab": "Bamboo Mosaic Vertical Slab",
 	"block.quark.bamboo_post": "Bamboo Post",


### PR DESCRIPTION
`block.quark.cherry_vertical_slab` appears twice in `en_us.json`. This PR removes the duplicate entry.