### PR TITLE
Fix freestanding ladders not popping off when the top is broken (Fixes #4843)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,5 @@
 - Fallen logs can no longer spawn on ice and other non terrain blocks (added tag for them)
 - Fallen log decoration (moss and vines) are now biome temperature and humidify dependent. No more moss in snowy biomes
 - Freestanding ladders will now break off the wall when you break the top block
-
 - Matrix Enchanting Table appears in creative if automaticallyConvert is off
 - Fixed Skull Pikes not functioning when there's a block on top, by lowering the detection point

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
 - Fallen logs can rarely spawn on water
 - Fallen logs can no longer spawn on ice and other non terrain blocks (added tag for them)
 - Fallen log decoration (moss and vines) are now biome temperature and humidify dependent. No more moss in snowy biomes
+- Freestanding ladders will now break off the wall when you break the top block

--- a/src/main/java/org/violetmoon/quark/content/tweaks/module/EnhancedLaddersModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/module/EnhancedLaddersModule.java
@@ -4,7 +4,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.Input;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.Direction.Axis;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
@@ -21,13 +20,13 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LadderBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.VoxelShape;
@@ -64,9 +63,11 @@ public class EnhancedLaddersModule extends ZetaModule {
 	@Config
 	public static boolean allowInventorySneak = true;
 
-	private static boolean staticEnabled;
+	public static boolean staticEnabled;
 	private static TagKey<Item> laddersTag;
 	private static TagKey<Block> laddersBlockTag;
+
+	private static final DirectionProperty FACING = LadderBlock.FACING;
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
@@ -106,35 +107,19 @@ public class EnhancedLaddersModule extends ZetaModule {
 			event.accept(item, comp);
 	}
 
-	private static boolean canAttachTo(BlockState state, Block ladder, LevelReader world, BlockPos pos, Direction facing) {
-		if(ladder instanceof LadderBlock) {
-			if(allowFreestanding)
-				return canLadderSurvive(state, world, pos);
+	// see LadderBlockMixin
+	public static boolean canSurviveTweak(boolean vanillaSurvive, BlockState state, LevelReader world, BlockPos pos) {
+		//With the freestanding feature enabled, ladders can survive if they are supported by a block (vanillaSurvive),
+		//or if they are underneath a ladder on the same wall.
+		if(vanillaSurvive)
+			return true;
 
-			BlockPos offset = pos.relative(facing);
-			BlockState blockstate = world.getBlockState(offset);
-			return !blockstate.isSignalSource() && blockstate.isFaceSturdy(world, offset, facing);
-		}
-
-		return false;
-	}
-
-	// replaces ladder survives logic
-	public static boolean canLadderSurvive(BlockState state, LevelReader world, BlockPos pos) {
-		if(!staticEnabled || !allowFreestanding)
+		if(!staticEnabled || !allowFreestanding || !state.is(laddersBlockTag) || !state.hasProperty(FACING))
 			return false;
-		if(!state.is(laddersBlockTag))return false;
 
-		Direction facing = state.getValue(LadderBlock.FACING);
-		Direction opposite = facing.getOpposite();
-		BlockPos oppositePos = pos.relative(opposite);
-		BlockState oppositeState = world.getBlockState(oppositePos);
-
-		boolean solid =  oppositeState.isFaceSturdy(world, oppositePos, facing) && !(oppositeState.getBlock() instanceof LadderBlock);
-		BlockState topState = world.getBlockState(pos.above());
-		return solid || (topState.getBlock() instanceof LadderBlock && (facing.getAxis() == Axis.Y || topState.getValue(LadderBlock.FACING) == facing));
+		BlockState aboveState = world.getBlockState(pos.above());
+		return aboveState.is(laddersBlockTag) && aboveState.hasProperty(FACING) && aboveState.getValue(FACING) == state.getValue(FACING);
 	}
-
 
 	@PlayEvent
 	public void onInteract(ZRightClickBlock event) {
@@ -164,8 +149,7 @@ public class EnhancedLaddersModule extends ZetaModule {
 					if(water || stateDown.isAir()) {
 						BlockState copyState = world.getBlockState(pos);
 
-						Direction facing = copyState.getValue(LadderBlock.FACING);
-						if(canAttachTo(copyState, block, world, posDown, facing.getOpposite())) {
+						if(copyState.canSurvive(world, posDown)) {
 							world.setBlockAndUpdate(posDown, copyState.setValue(BlockStateProperties.WATERLOGGED, water));
 							world.playSound(null, posDown.getX(), posDown.getY(), posDown.getZ(), SoundEvents.LADDER_PLACE, SoundSource.BLOCKS, 1F, 1F);
 

--- a/src/main/java/org/violetmoon/quark/content/tweaks/module/EnhancedLaddersModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/module/EnhancedLaddersModule.java
@@ -121,6 +121,10 @@ public class EnhancedLaddersModule extends ZetaModule {
 		return aboveState.is(laddersBlockTag) && aboveState.hasProperty(FACING) && aboveState.getValue(FACING) == state.getValue(FACING);
 	}
 
+	public static boolean shouldDoUpdateShapeTweak(BlockState state) {
+		return staticEnabled && allowFreestanding && state.is(laddersBlockTag);
+	}
+
 	@PlayEvent
 	public void onInteract(ZRightClickBlock event) {
 		if(!allowDroppingDown) return;

--- a/src/main/java/org/violetmoon/quark/mixin/mixins/BlockBehaviourMixin.java
+++ b/src/main/java/org/violetmoon/quark/mixin/mixins/BlockBehaviourMixin.java
@@ -1,0 +1,22 @@
+package org.violetmoon.quark.mixin.mixins;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Exists to be subclassed by LadderBlockMixin basically
+ */
+@Mixin(BlockBehaviour.class)
+public class BlockBehaviourMixin {
+	@Inject(method = "tick", at = @At("HEAD"))
+	public void quark$tick(BlockState pState, ServerLevel pLevel, BlockPos pPos, RandomSource pRandom, CallbackInfo ci) {
+
+	}
+}

--- a/src/main/java/org/violetmoon/quark/mixin/mixins/LadderBlockMixin.java
+++ b/src/main/java/org/violetmoon/quark/mixin/mixins/LadderBlockMixin.java
@@ -1,30 +1,58 @@
 package org.violetmoon.quark.mixin.mixins;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.LadderBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 import org.violetmoon.quark.content.tweaks.module.EnhancedLaddersModule;
 
 @Mixin(LadderBlock.class)
-public class LadderBlockMixin {
+public class LadderBlockMixin extends Block {
+	public LadderBlockMixin(Properties pProperties) {
+		super(pProperties);
+		throw new AssertionError("Mixin dummy constructor");
+	}
 
+	@ModifyReturnValue(method = "canSurvive", at = @At("RETURN"))
+	private boolean canSurviveTweak(boolean original, BlockState state, LevelReader level, BlockPos pos) {
+		return EnhancedLaddersModule.canSurviveTweak(original, state, level, pos);
+	}
 
-	@Inject(method = "canSurvive", at = @At("HEAD"), cancellable = true)
-	private void canSurvive(BlockState state, LevelReader level, BlockPos pos, CallbackInfoReturnable<Boolean> callbackInfoReturnable) {
-		if(EnhancedLaddersModule.canLadderSurvive(state, level, pos)) {
-			callbackInfoReturnable.setReturnValue(true);
-			callbackInfoReturnable.cancel();
+	/**
+	 * In vanilla, the only way to break a ladder is to break the block behind it. So in updateShape,
+	 * vanilla only does ladder canSurvive checks if the update came from behind. But with Quark's
+	 * freestanding ladder feature, it's possible to break a ladder by breaking a block *above* it.
+	 */
+	@Inject(method = "updateShape", at = @At(value = "HEAD"), cancellable = true)
+	private void updateShapeTweak(BlockState pState, Direction pFacing, BlockState pFacingState, LevelAccessor pLevel, BlockPos pCurrentPos, BlockPos pFacingPos, CallbackInfoReturnable<BlockState> cir) {
+		if(EnhancedLaddersModule.staticEnabled && EnhancedLaddersModule.allowFreestanding && pFacing == Direction.UP) {
+			//This is just for fun. Makes the ladders break like bamboo instead of instantly.
+			pLevel.scheduleTick(pCurrentPos, (LadderBlock) (Object) this, 1);
+			cir.setReturnValue(pState);
 		}
 	}
 
+	@Override
+	public void tick(BlockState pState, ServerLevel pLevel, BlockPos pPos, RandomSource pRandom) {
+		if(EnhancedLaddersModule.staticEnabled && EnhancedLaddersModule.allowFreestanding && !pState.canSurvive(pLevel, pPos)) {
+			pLevel.destroyBlock(pPos, true);
+		}
+
+		super.tick(pState, pLevel, pPos, pRandom);
+	}
 }

--- a/src/main/java/org/violetmoon/quark/mixin/mixins/LadderBlockMixin.java
+++ b/src/main/java/org/violetmoon/quark/mixin/mixins/LadderBlockMixin.java
@@ -40,7 +40,7 @@ public class LadderBlockMixin extends Block {
 	 */
 	@Inject(method = "updateShape", at = @At(value = "HEAD"), cancellable = true)
 	private void updateShapeTweak(BlockState pState, Direction pFacing, BlockState pFacingState, LevelAccessor pLevel, BlockPos pCurrentPos, BlockPos pFacingPos, CallbackInfoReturnable<BlockState> cir) {
-		if(EnhancedLaddersModule.staticEnabled && EnhancedLaddersModule.allowFreestanding && pFacing == Direction.UP) {
+		if(EnhancedLaddersModule.shouldDoUpdateShapeTweak(pState) && pFacing == Direction.UP) {
 			//This is just for fun. Makes the ladders break like bamboo instead of instantly.
 			pLevel.scheduleTick(pCurrentPos, (LadderBlock) (Object) this, 1);
 			cir.setReturnValue(pState);
@@ -49,7 +49,7 @@ public class LadderBlockMixin extends Block {
 
 	@Override
 	public void tick(BlockState pState, ServerLevel pLevel, BlockPos pPos, RandomSource pRandom) {
-		if(EnhancedLaddersModule.staticEnabled && EnhancedLaddersModule.allowFreestanding && !pState.canSurvive(pLevel, pPos)) {
+		if(EnhancedLaddersModule.shouldDoUpdateShapeTweak(pState) && !pState.canSurvive(pLevel, pPos)) {
 			pLevel.destroyBlock(pPos, true);
 		}
 

--- a/src/main/java/org/violetmoon/quark/mixin/mixins/LadderBlockMixin.java
+++ b/src/main/java/org/violetmoon/quark/mixin/mixins/LadderBlockMixin.java
@@ -18,16 +18,12 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.violetmoon.quark.content.tweaks.module.EnhancedLaddersModule;
 
 @Mixin(LadderBlock.class)
-public class LadderBlockMixin extends Block {
-	public LadderBlockMixin(Properties pProperties) {
-		super(pProperties);
-		throw new AssertionError("Mixin dummy constructor");
-	}
-
+public class LadderBlockMixin extends BlockBehaviourMixin {
 	@ModifyReturnValue(method = "canSurvive", at = @At("RETURN"))
 	private boolean canSurviveTweak(boolean original, BlockState state, LevelReader level, BlockPos pos) {
 		return EnhancedLaddersModule.canSurviveTweak(original, state, level, pos);
@@ -47,12 +43,13 @@ public class LadderBlockMixin extends Block {
 		}
 	}
 
+	/**
+	 * Override from BlockBehaviourMixin which does the actual injection
+	 */
 	@Override
-	public void tick(BlockState pState, ServerLevel pLevel, BlockPos pPos, RandomSource pRandom) {
+	public void quark$tick(BlockState pState, ServerLevel pLevel, BlockPos pPos, RandomSource pRandom, CallbackInfo ci) {
 		if(EnhancedLaddersModule.shouldDoUpdateShapeTweak(pState) && !pState.canSurvive(pLevel, pPos)) {
 			pLevel.destroyBlock(pPos, true);
 		}
-
-		super.tick(pState, pLevel, pPos, pRandom);
 	}
 }

--- a/src/main/resources/quark.mixins.json
+++ b/src/main/resources/quark.mixins.json
@@ -16,6 +16,7 @@
     "BaseCoralPlantTypeBlockMixin",
     "BeaconBlockEntityMixin",
     "BeehiveBlockEntityMixin",
+    "BlockBehaviourMixin",
     "BlockItemMixin",
     "BoatMixin",
     "CeilingHangingSignBlockMixin",


### PR DESCRIPTION
Also simplifies the EnhancedLaddersModule logic a little bit w/ some mixinextras sauce.

Fixes #4843 

The problem is that in vanilla, the only way to make a ladder pop off the wall is to break the block behind it, and therefore the `canSurvive` checks in vanilla don't run if the block update came from a different direction. The fix is to run canSurvive logic when blocks above send updates, too.

Just for fun I made the ladders break off like bamboo. This required overriding `tick` from LadderBlock and I'm not sure if that's kosher. Would like some eyes on this before I accidentally introduce a ladder dupe bug