### PR TITLE
Use a safer way to convert attribute map when parsing tooltips

### DIFF
--- a/src/main/java/vazkii/quark/content/client/tooltip/AttributeTooltips.java
+++ b/src/main/java/vazkii/quark/content/client/tooltip/AttributeTooltips.java
@@ -252,9 +252,19 @@ public class AttributeTooltips {
 		}
 
 		Multimap<Attribute, AttributeModifier> out = stack.getAttributeModifiers(slot);
-		if(out.isEmpty())
+		if(out.isEmpty()) {
 			out = HashMultimap.create();
-		else out = HashMultimap.create(out); // convert to our own map
+		} else {
+			// convert to our own map
+			Multimap<Attribute, AttributeModifier> filtered = HashMultimap.create();
+			for (Map.Entry<Attribute, AttributeModifier> entry : out.entries()) {
+				AttributeModifier modifier = entry.getValue();
+				if (modifier.getId() != null) {
+					filtered.put(entry.getKey(), modifier);
+				}
+			}
+			out = filtered;
+		}
 
 		if (slot == EquipmentSlot.MAINHAND) {
 			if (EnchantmentHelper.getDamageBonus(stack, MobType.UNDEFINED) > 0)


### PR DESCRIPTION
When try rendering some bug-item's tooltip in which doesn't have the correct AttributeModifier information, even it's not a bug from the quark, quark will crash the client and generate a crash report with this:
``` java
[Render thread/INFO] [ChunkBuilder/]: Stopping worker threads
[Render thread/ERROR] [net.minecraft.client.Minecraft/FATAL]: Reported exception thrown!
net.minecraft.ReportedException: Rendering screen
	at net.minecraft.client.renderer.GameRenderer.m_109093_(GameRenderer.java:903) ~[client-1.18.2-20220404.173914-srg.jar%23221!/:?]
	at net.minecraft.client.Minecraft.m_91383_(Minecraft.java:1046) ~[client-1.18.2-20220404.173914-srg.jar%23221!/:?]
	at net.minecraft.client.Minecraft.m_91374_(Minecraft.java:665) ~[client-1.18.2-20220404.173914-srg.jar%23221!/:?]
	at net.minecraft.client.main.Main.main(Main.java:205) ~[client-1.18.2-20220404.173914-srg.jar%23221!/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
	at net.minecraftforge.fml.loading.targets.CommonClientLaunchHandler.lambda$launchService$0(CommonClientLaunchHandler.java:31) ~[fmlloader-1.18.2-40.2.10.jar%2318!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:37) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:106) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:77) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:149) [bootstraplauncher-1.0.0.jar:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
	at oolloo.jlw.Wrapper.invokeMain(Wrapper.java:71) [JavaWrapper.jar:?]
	at oolloo.jlw.Wrapper.main(Wrapper.java:51) [JavaWrapper.jar:?]
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.UUID.hashCode()" because "this.f_22193_" is null
	at net.minecraft.world.entity.ai.attributes.AttributeModifier.hashCode(AttributeModifier.java:95) ~[client-1.18.2-20220404.173914-srg.jar%23221!/:?]
	at java.util.HashMap.hash(HashMap.java:338) ~[?:?]
	at java.util.HashMap.put(HashMap.java:610) ~[?:?]
	at java.util.HashSet.add(HashSet.java:221) ~[?:?]
	at com.google.common.collect.AbstractMapBasedMultimap.put(AbstractMapBasedMultimap.java:191) ~[guava-31.0.1-jre.jar%2330!/:?]
	at com.google.common.collect.AbstractSetMultimap.put(AbstractSetMultimap.java:140) ~[guava-31.0.1-jre.jar%2330!/:?]
	at com.google.common.collect.HashMultimap.put(HashMultimap.java:51) ~[guava-31.0.1-jre.jar%2330!/:?]
	at com.google.common.collect.AbstractMultimap.putAll(AbstractMultimap.java:100) ~[guava-31.0.1-jre.jar%2330!/:?]
	at com.google.common.collect.HashMultimap.putAll(HashMultimap.java:51) ~[guava-31.0.1-jre.jar%2330!/:?]
	at com.google.common.collect.HashMultimap.<init>(HashMultimap.java:114) ~[guava-31.0.1-jre.jar%2330!/:?]
	at com.google.common.collect.HashMultimap.create(HashMultimap.java:99) ~[guava-31.0.1-jre.jar%2330!/:?]
	at vazkii.quark.content.client.tooltip.AttributeTooltips.getModifiers(AttributeTooltips.java:257) ~[Quark-3.2-358.jar%23190!/:3.2-358]
	at vazkii.quark.content.client.tooltip.AttributeTooltips.makeTooltip(AttributeTooltips.java:169) ~[Quark-3.2-358.jar%23190!/:3.2-358]
	at vazkii.quark.content.client.module.ImprovedTooltipsModule.makeTooltip(ImprovedTooltipsModule.java:104) ~[Quark-3.2-358.jar%23190!/:3.2-358]
	at net.minecraftforge.eventbus.ASMEventHandler_1659_ImprovedTooltipsModule_makeTooltip_GatherComponents.invoke(.dynamic) ~[?:?]
	at net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:85) ~[eventbus-5.0.3.jar%232!/:?]
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:302) ~[eventbus-5.0.3.jar%232!/:?]
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:283) ~[eventbus-5.0.3.jar%232!/:?]
	at net.minecraftforge.client.ForgeHooksClient.gatherTooltipComponents(ForgeHooksClient.java:1039) ~[forge-1.18.2-40.2.10-universal.jar%23226!/:?]
	at net.minecraft.client.gui.screens.Screen.m_169388_(Screen.java:189) ~[client-1.18.2-20220404.173914-srg.jar%23221!/:?]
	at net.minecraft.client.gui.screens.Screen.renderTooltip(Screen.java:184) ~[client-1.18.2-20220404.173914-srg.jar%23221!/:?]
	at mezz.jei.forge.platform.RenderHelper.renderTooltip(RenderHelper.java:73) ~[jei-1.18.2-forge-10.2.1.1006.jar%23164!/:10.2.1.1006]
	at mezz.jei.common.gui.TooltipRenderer.drawHoveringText(TooltipRenderer.java:43) ~[jei-1.18.2-forge-10.2.1.1006.jar%23164!/:10.2.1.1006]
	at mezz.jei.common.gui.TooltipRenderer.drawHoveringText(TooltipRenderer.java:31) ~[jei-1.18.2-forge-10.2.1.1006.jar%23164!/:10.2.1.1006]
	at mezz.jei.common.gui.overlay.IngredientGridTooltipHelper.drawTooltip(IngredientGridTooltipHelper.java:55) ~[jei-1.18.2-forge-10.2.1.1006.jar%23164!/:10.2.1.1006]
	at mezz.jei.common.gui.overlay.IngredientGrid.lambda$drawTooltips$3(IngredientGrid.java:180) ~[jei-1.18.2-forge-10.2.1.1006.jar%23164!/:10.2.1.1006]
	at java.util.Optional.ifPresent(Optional.java:178) ~[?:?]
	at mezz.jei.common.gui.overlay.IngredientGrid.drawTooltips(IngredientGrid.java:180) ~[jei-1.18.2-forge-10.2.1.1006.jar%23164!/:10.2.1.1006]
	at mezz.jei.common.gui.overlay.IngredientGridWithNavigation.drawTooltips(IngredientGridWithNavigation.java:189) ~[jei-1.18.2-forge-10.2.1.1006.jar%23164!/:10.2.1.1006]
	at mezz.jei.common.gui.overlay.IngredientListOverlay.drawTooltips(IngredientListOverlay.java:198) ~[jei-1.18.2-forge-10.2.1.1006.jar%23164!/:10.2.1.1006]
	at mezz.jei.common.gui.GuiEventHandler.onDrawScreenPost(GuiEventHandler.java:103) ~[jei-1.18.2-forge-10.2.1.1006.jar%23164!/:10.2.1.1006]
	at mezz.jei.forge.startup.EventRegistration.lambda$registerGuiHandler$14(EventRegistration.java:117) ~[jei-1.18.2-forge-10.2.1.1006.jar%23164!/:10.2.1.1006]
	at mezz.jei.core.util.WeakConsumer.accept(WeakConsumer.java:17) ~[jei-1.18.2-forge-10.2.1.1006.jar%23164!/:10.2.1.1006]
	at net.minecraftforge.eventbus.EventBus.doCastFilter(EventBus.java:247) ~[eventbus-5.0.3.jar%232!/:?]
	at net.minecraftforge.eventbus.EventBus.lambda$addListener$11(EventBus.java:239) ~[eventbus-5.0.3.jar%232!/:?]
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:302) ~[eventbus-5.0.3.jar%232!/:?]
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:283) ~[eventbus-5.0.3.jar%232!/:?]
	at net.minecraftforge.client.ForgeHooksClient.drawScreenInternal(ForgeHooksClient.java:404) ~[forge-1.18.2-40.2.10-universal.jar%23226!/:?]
	at net.minecraftforge.client.ForgeHooksClient.drawScreen(ForgeHooksClient.java:396) ~[forge-1.18.2-40.2.10-universal.jar%23226!/:?]
	at net.minecraft.client.renderer.GameRenderer.m_109093_(GameRenderer.java:890) ~[client-1.18.2-20220404.173914-srg.jar%23221!/:?]
	... 22 more
```

So we can make it safer when rendering tooltip for this bug item, for preventing it crashes the client