### PR TITLE
Fix SlabsToBlocksModule finding the wrong recipe for certain slabs

### DIFF
--- a/src/main/java/org/violetmoon/quark/content/tweaks/module/SlabsToBlocksModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/module/SlabsToBlocksModule.java
@@ -44,6 +44,7 @@ public class SlabsToBlocksModule extends ZetaModule {
 		if(visit.ingredients.size() == 3
 				&& visit.recipe.getHeight() == 1
 				&& visit.recipe.getWidth() == 3
+				&& visit.output.getCount() == 6
 				&& visit.output.getItem() instanceof BlockItem bi
 				&& bi.getBlock() instanceof SlabBlock) {
 


### PR DESCRIPTION
Fixes #4863 as well as any other cases where a slab recipe results in more or less than 6 slabs from 3 blocks