### PR TITLE
make buttons non flammable. fix #4881

### DIFF
--- a/src/main/resources/data/minecraft/tags/items/non_flammable_wood.json
+++ b/src/main/resources/data/minecraft/tags/items/non_flammable_wood.json
@@ -8,6 +8,9 @@
 	"quark:warped_post",
 	"quark:crimson_post",
 	"quark:warped_bookshelf",
-	"quark:crimson_bookshelf"
+	"quark:crimson_bookshelf",
+	"quark:ancient_button",
+	"quark:azalea_button",
+	"quark:blossom_button"
   ]
 }


### PR DESCRIPTION
Added ancient, azalea, and blossom buttons to non_flammable_wood block tags.

I'm not sure why Zeta uses the SoundType instead of the Material to make things flammable, but that's the reason why Quark's buttons were flammable while vanilla buttons (and torches, levers, repeaters, etc. which all have wood SoundType but decoration Material) are not.

#Modtoberfest2024