### PR TITLE
1.21.1 porting chore: ResourceLocation/Key

### DIFF
--- a/src/main/java/org/violetmoon/quark/addons/oddities/client/render/be/PipeRenderer.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/client/render/be/PipeRenderer.java
@@ -34,7 +34,7 @@ import java.util.Random;
 
 public class PipeRenderer implements BlockEntityRenderer<PipeBlockEntity> {
 
-	private static final ModelResourceLocation LOCATION_MODEL = new ModelResourceLocation(new ResourceLocation(Quark.MOD_ID, "extra/pipe_flare"), "inventory");
+	private static final ModelResourceLocation LOCATION_MODEL = new ModelResourceLocation(Quark.asResource("extra/pipe_flare"), "inventory");
 
 	private final Random random = new Random();
 

--- a/src/main/java/org/violetmoon/quark/addons/oddities/client/render/be/TinyPotatoRenderer.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/client/render/be/TinyPotatoRenderer.java
@@ -27,6 +27,7 @@ import org.jetbrains.annotations.NotNull;
 import org.violetmoon.quark.addons.oddities.block.be.TinyPotatoBlockEntity;
 import org.violetmoon.quark.addons.oddities.module.TinyPotatoModule;
 import org.violetmoon.quark.addons.oddities.util.TinyPotatoInfo;
+import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.content.tools.base.RuneColor;
 import org.violetmoon.quark.content.tools.module.ColorRunesModule;
 import org.violetmoon.quark.mixin.mixins.client.accessor.AccessorModelManager;
@@ -76,7 +77,7 @@ public class TinyPotatoRenderer implements BlockEntityRenderer<TinyPotatoBlockEn
 	}
 
 	private static ResourceLocation taterLocation(String name) {
-		return new ResourceLocation("quark", "tiny_potato/" + normalizeName(name));
+		return Quark.asResource( "tiny_potato/" + normalizeName(name));
 	}
 
 	private static String normalizeName(String name) {

--- a/src/main/java/org/violetmoon/quark/addons/oddities/client/screen/BackpackInventoryScreen.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/client/screen/BackpackInventoryScreen.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 public class BackpackInventoryScreen extends InventoryScreen implements IQuarkButtonAllowed {
 
-	private static final ResourceLocation BACKPACK_INVENTORY_BACKGROUND = new ResourceLocation(Quark.MOD_ID, "textures/misc/backpack_gui.png");
+	private static final ResourceLocation BACKPACK_INVENTORY_BACKGROUND = Quark.asResource("textures/misc/backpack_gui.png");
 
 	private final Player player;
 	private final Map<Button, Integer> buttonYs = new HashMap<>();

--- a/src/main/java/org/violetmoon/quark/addons/oddities/client/screen/CrateScreen.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/client/screen/CrateScreen.java
@@ -24,7 +24,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
 public class CrateScreen extends AbstractContainerScreen<CrateMenu> implements IQuarkButtonAllowed {
-	private static final ResourceLocation TEXTURE = new ResourceLocation(Quark.MOD_ID, "textures/gui/crate.png");
+	private static final ResourceLocation TEXTURE = Quark.asResource("textures/gui/crate.png");
 
 	private int lastScroll;
 	private int scrollOffs;

--- a/src/main/java/org/violetmoon/quark/addons/oddities/client/screen/MatrixEnchantingScreen.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/client/screen/MatrixEnchantingScreen.java
@@ -35,7 +35,7 @@ import net.minecraft.world.item.Items;
 
 public class MatrixEnchantingScreen extends AbstractContainerScreen<MatrixEnchantingMenu> {
 
-	public static final ResourceLocation BACKGROUND = new ResourceLocation(Quark.MOD_ID, "textures/misc/matrix_enchanting.png");
+	public static final ResourceLocation BACKGROUND = Quark.asResource("textures/misc/matrix_enchanting.png");
 
 	protected final Inventory playerInv;
 	protected final MatrixEnchantingTableBlockEntity enchanter;

--- a/src/main/java/org/violetmoon/quark/addons/oddities/inventory/EnchantmentMatrix.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/inventory/EnchantmentMatrix.java
@@ -481,7 +481,7 @@ public class EnchantmentMatrix {
 		public void readFromNBT(CompoundTag cmp) {
 			color = cmp.getInt(TAG_COLOR);
 			type = cmp.getInt(TAG_TYPE);
-			enchant = BuiltInRegistries.ENCHANTMENT.get(new ResourceLocation(cmp.getString(TAG_ENCHANTMENT)));
+			enchant = BuiltInRegistries.ENCHANTMENT.get(ResourceLocation.parse(cmp.getString(TAG_ENCHANTMENT)));
 			level = cmp.getInt(TAG_LEVEL);
 			x = cmp.getInt(TAG_X);
 			y = cmp.getInt(TAG_Y);

--- a/src/main/java/org/violetmoon/quark/addons/oddities/module/BackpackModule.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/module/BackpackModule.java
@@ -113,7 +113,7 @@ public class BackpackModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		backpackBlockedTag = ItemTags.create(new ResourceLocation(Quark.MOD_ID, "backpack_blocked"));
+		backpackBlockedTag = ItemTags.create(Quark.asResource("backpack_blocked"));
 	}
 
 	@PlayEvent
@@ -193,7 +193,7 @@ public class BackpackModule extends ZetaModule {
 			e.enqueueWork(() -> {
 				MenuScreens.register(menyType, BackpackInventoryScreen::new);
 
-				ItemProperties.register(backpack, new ResourceLocation("has_items"),
+				ItemProperties.register(backpack, Quark.asResource("has_items"),
 						(stack, world, entity, i) -> (!BackpackModule.superOpMode && BackpackItem.doesBackpackHaveItems(stack)) ? 1 : 0);
 
 				QuarkClient.ZETA_CLIENT.setHumanoidArmorModel(backpack.asItem(), (living, stack, slot, original) -> ModelHandler.armorModel(ModelHandler.backpack, slot));

--- a/src/main/java/org/violetmoon/quark/addons/oddities/module/MagnetsModule.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/module/MagnetsModule.java
@@ -70,7 +70,7 @@ public class MagnetsModule extends ZetaModule {
 	@Config(description = "The maximum hardness of a block that a stonecutter pushed by magnets can cut through.")
     public static double stoneCutterMaxHardness = 3;
 
-    public static final TagKey<EntityType<?>> magneticEntities = TagKey.create(Registries.ENTITY_TYPE, Quark.asResource("affected_by_magnets"));
+    public static final TagKey<EntityType<?>> magneticEntities = Quark.asTagKey(Registries.ENTITY_TYPE,"affected_by_magnets");
 
     @Hint
     public static Block magnet;

--- a/src/main/java/org/violetmoon/quark/addons/oddities/module/MatrixEnchantingModule.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/module/MatrixEnchantingModule.java
@@ -223,7 +223,7 @@ public class MatrixEnchantingModule extends ZetaModule {
 			if(damp)
 				enchStr = enchStr.substring(1);
 
-			Enchantment ench = BuiltInRegistries.ENCHANTMENT.get(new ResourceLocation(enchStr));
+			Enchantment ench = BuiltInRegistries.ENCHANTMENT.get(ResourceLocation.parse(enchStr));
 			if(ench != null) {
 				if(damp)
 					dampen.add(ench);

--- a/src/main/java/org/violetmoon/quark/addons/oddities/module/PipesModule.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/module/PipesModule.java
@@ -67,7 +67,7 @@ public class PipesModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		pipesTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "pipes"));
+		pipesTag = BlockTags.create(Quark.asResource("pipes"));
 	}
 
 	@LoadEvent
@@ -84,7 +84,7 @@ public class PipesModule extends ZetaModule {
 
 		@LoadEvent
 		public void registerAdditionalModels(ZAddModels event) {
-			event.register(new ModelResourceLocation(Quark.MOD_ID, "extra/pipe_flare", "inventory"));
+			event.register(new ModelResourceLocation(Quark.asResource("extra/pipe_flare"), "inventory"));
 		}
 	}
 }

--- a/src/main/java/org/violetmoon/quark/addons/oddities/module/TinyPotatoModule.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/module/TinyPotatoModule.java
@@ -57,8 +57,8 @@ public class TinyPotatoModule extends ZetaModule {
 	public static class Client extends TinyPotatoModule {
 		@LoadEvent
 		public void modelBake(ZModel.ModifyBakingResult event) {
-			ResourceLocation tinyPotato = new ModelResourceLocation(new ResourceLocation("quark", "tiny_potato"), "inventory");
-			Map<ResourceLocation, BakedModel> map = event.getModels();
+			ModelResourceLocation tinyPotato = ModelResourceLocation.inventory(Quark.asResource("tiny_potato"));
+			Map<ModelResourceLocation, BakedModel> map = event.getModels();
 			BakedModel originalPotato = map.get(tinyPotato);
 			map.put(tinyPotato, new TinyPotatoModel(originalPotato));
 		}
@@ -84,7 +84,7 @@ public class TinyPotatoModule extends ZetaModule {
 					usedNames.add(path);
 
 					path = path.substring("models/".length(), path.length() - ".json".length());
-					event.register(new ResourceLocation("quark", path));
+					event.register(Quark.asResource(path));
 				}
 			}
 		}

--- a/src/main/java/org/violetmoon/quark/base/Quark.java
+++ b/src/main/java/org/violetmoon/quark/base/Quark.java
@@ -3,7 +3,8 @@ package org.violetmoon.quark.base;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.fml.common.Mod;
+import net.minecraft.tags.TagKey;
+import net.neoforged.fml.common.Mod;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.MixinEnvironment;
@@ -57,11 +58,15 @@ public class Quark {
 			MixinEnvironment.getCurrentEnvironment().audit();
 	}
 
-	public static ResourceLocation asResource(String name) {
-		return new ResourceLocation(MOD_ID, name);
+	public static ResourceLocation asResource(String path) {
+		return ResourceLocation.fromNamespaceAndPath(MOD_ID, path);
 	}
 
 	public static <T> ResourceKey<T> asResourceKey(ResourceKey<? extends Registry<T>> base, String name) {
 		return ResourceKey.create(base, asResource(name));
+	}
+
+	public static <T> TagKey<T> asTagKey(ResourceKey<? extends Registry<T>> base, String name) {
+		return TagKey.create(base, asResource(name));
 	}
 }

--- a/src/main/java/org/violetmoon/quark/base/capability/CapabilityHandler.java
+++ b/src/main/java/org/violetmoon/quark/base/capability/CapabilityHandler.java
@@ -14,10 +14,10 @@ import org.violetmoon.zeta.event.play.loading.ZAttachCapabilities;
 
 // TODO: push these event handlers into their respective modules
 public class CapabilityHandler {
-	private static final ResourceLocation DROPOFF_MANAGER = new ResourceLocation(Quark.MOD_ID, "dropoff");
-	private static final ResourceLocation SORTING_HANDLER = new ResourceLocation(Quark.MOD_ID, "sort");
-	private static final ResourceLocation MAGNET_TRACKER = new ResourceLocation(Quark.MOD_ID, "magnet_tracker");
-	private static final ResourceLocation RUNE_COLOR_HANDLER = new ResourceLocation(Quark.MOD_ID, "rune_color");
+	private static final ResourceLocation DROPOFF_MANAGER = Quark.asResource("dropoff");
+	private static final ResourceLocation SORTING_HANDLER = Quark.asResource("sort");
+	private static final ResourceLocation MAGNET_TRACKER = Quark.asResource("magnet_tracker");
+	private static final ResourceLocation RUNE_COLOR_HANDLER = Quark.asResource("rune_color");
 
 	@PlayEvent
 	public static void attachItemCapabilities(ZAttachCapabilities.ItemStackCaps event) {

--- a/src/main/java/org/violetmoon/quark/base/client/config/QuarkConfigHomeScreen.java
+++ b/src/main/java/org/violetmoon/quark/base/client/config/QuarkConfigHomeScreen.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public class QuarkConfigHomeScreen extends ZetaConfigHomeScreen {
 
-	private static final CubeMap CUBE_MAP = new CubeMap(new ResourceLocation(Quark.MOD_ID, "textures/misc/panorama/panorama"));
+	private static final CubeMap CUBE_MAP = new CubeMap(Quark.asResource("textures/misc/panorama/panorama"));
 	private static final PanoramaRenderer PANORAMA = new PanoramaRenderer(CUBE_MAP);
 	private float time;
 

--- a/src/main/java/org/violetmoon/quark/base/client/config/SocialButton.java
+++ b/src/main/java/org/violetmoon/quark/base/client/config/SocialButton.java
@@ -16,7 +16,7 @@ import org.violetmoon.quark.base.Quark;
 
 public class SocialButton extends Button {
 
-	public static final ResourceLocation SOCIAL_ICONS = new ResourceLocation(Quark.MOD_ID, "textures/gui/social_icons.png");
+	public static final ResourceLocation SOCIAL_ICONS = Quark.asResource("textures/gui/social_icons.png");
 
 	private final int textColor;
 	private final int socialId;

--- a/src/main/java/org/violetmoon/quark/base/client/handler/ClientUtil.java
+++ b/src/main/java/org/violetmoon/quark/base/client/handler/ClientUtil.java
@@ -23,7 +23,7 @@ import net.minecraft.resources.ResourceLocation;
 
 public class ClientUtil {
 
-	public static final ResourceLocation GENERAL_ICONS = new ResourceLocation(Quark.MOD_ID, "textures/gui/general_icons.png");
+	public static final ResourceLocation GENERAL_ICONS = Quark.asResource("textures/gui/general_icons.png");
 
 	private static int progress;
 

--- a/src/main/java/org/violetmoon/quark/base/client/handler/ModelHandler.java
+++ b/src/main/java/org/violetmoon/quark/base/client/handler/ModelHandler.java
@@ -82,7 +82,7 @@ public class ModelHandler {
 	}
 
 	private static ModelLayerLocation addLayer(String name, Layer layer) {
-		ModelLayerLocation loc = new ModelLayerLocation(new ResourceLocation(Quark.MOD_ID, name), "main");
+		ModelLayerLocation loc = new ModelLayerLocation(Quark.asResource(name), "main");
 		layers.put(loc, layer);
 		return loc;
 	}

--- a/src/main/java/org/violetmoon/quark/base/client/render/QuarkBoatRenderer.java
+++ b/src/main/java/org/violetmoon/quark/base/client/render/QuarkBoatRenderer.java
@@ -43,7 +43,7 @@ public class QuarkBoatRenderer extends EntityRenderer<Boat> {
 	private static Map<String, BoatModelTuple> computeBoatResources(boolean chest, EntityRendererProvider.Context context) {
 		return WoodSetHandler.boatTypes().collect(ImmutableMap.toImmutableMap(Functions.identity(), name -> {
 			String folder = chest ? "chest_boat" : "boat";
-			ResourceLocation texture = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/" + folder + "/" + name + ".png");
+			ResourceLocation texture = Quark.asResource("textures/model/entity/" + folder + "/" + name + ".png");
 			BoatModel model = (chest) ? new ChestBoatModel(context.bakeLayer(ModelHandler.quark_boat_chest)) : new BoatModel(context.bakeLayer(ModelHandler.quark_boat));
 
 			return new BoatModelTuple(texture, model);

--- a/src/main/java/org/violetmoon/quark/base/handler/ContributorRewardHandler.java
+++ b/src/main/java/org/violetmoon/quark/base/handler/ContributorRewardHandler.java
@@ -133,7 +133,7 @@ public class ContributorRewardHandler {
 				if(clientPlayer.isCapeLoaded()) {
 					PlayerInfo info = clientPlayer.playerInfo;
 					Map<MinecraftProfileTexture.Type, ResourceLocation> textures = info.textureLocations;
-					ResourceLocation loc = new ResourceLocation("quark", "textures/misc/dev_cape.png");
+					ResourceLocation loc = Quark.asResource("textures/misc/dev_cape.png");
 					textures.put(MinecraftProfileTexture.Type.CAPE, loc);
 					textures.put(MinecraftProfileTexture.Type.ELYTRA, loc);
 					done.add(uuid);

--- a/src/main/java/org/violetmoon/quark/base/handler/QuarkRemapHandler.java
+++ b/src/main/java/org/violetmoon/quark/base/handler/QuarkRemapHandler.java
@@ -47,7 +47,7 @@ public class QuarkRemapHandler {
 		for (var v : event.getMappings(block.key(), Quark.MOD_ID)) {
 			String rem = REMAP.get(v.getKey().toString());
 			if (rem != null) {
-				var b = block.getOptional(new ResourceLocation(rem));
+				var b = block.getOptional(ResourceLocation.parse(rem));
 				b.ifPresent(v::remap);
 			} else v.ignore();
 		}

--- a/src/main/java/org/violetmoon/quark/base/handler/QuarkSounds.java
+++ b/src/main/java/org/violetmoon/quark/base/handler/QuarkSounds.java
@@ -112,7 +112,7 @@ public class QuarkSounds {
 	}
 
 	public static SoundEvent register(String name) {
-		SoundEvent event = SoundEvent.createVariableRangeEvent(new ResourceLocation(Quark.MOD_ID, name));
+		SoundEvent event = SoundEvent.createVariableRangeEvent(Quark.asResource(name));
 		REGISTRY_DEFERENCE.add(event);
 		return event;
 	}

--- a/src/main/java/org/violetmoon/quark/base/handler/SortingHandler.java
+++ b/src/main/java/org/violetmoon/quark/base/handler/SortingHandler.java
@@ -343,7 +343,7 @@ public final class SortingHandler {
 				else if(o instanceof ItemStack stack)
 					itemList.add(stack.getItem());
 				else if(o instanceof String s) {
-					Item item = BuiltInRegistries.ITEM.get(new ResourceLocation(s));
+					Item item = BuiltInRegistries.ITEM.get(ResourceLocation.parse(s));
 					if(item != Items.AIR)
 						itemList.add(item);
 				}

--- a/src/main/java/org/violetmoon/quark/base/recipe/ExclusionRecipe.java
+++ b/src/main/java/org/violetmoon/quark/base/recipe/ExclusionRecipe.java
@@ -156,12 +156,12 @@ public class ExclusionRecipe implements CraftingRecipe {
 			JsonArray excluded = GsonHelper.getAsJsonArray(json, "exclusions");
 			List<ResourceLocation> excludedRecipes = new ArrayList<>();
 			for(JsonElement el : excluded) {
-				ResourceLocation loc = new ResourceLocation(el.getAsString());
+				ResourceLocation loc = ResourceLocation.parse(el.getAsString());
 				if(!loc.equals(recipeId))
 					excludedRecipes.add(loc);
 			}
 
-			RecipeSerializer<?> serializer = BuiltInRegistries.RECIPE_SERIALIZER.get(new ResourceLocation(trueType));
+			RecipeSerializer<?> serializer = BuiltInRegistries.RECIPE_SERIALIZER.get(ResourceLocation.parse(trueType));
 			if(serializer == null)
 				throw new JsonSyntaxException("Invalid or unsupported recipe type '" + trueType + "'");
 			Recipe<?> parent = serializer.fromJson(recipeId, json);
@@ -179,13 +179,13 @@ public class ExclusionRecipe implements CraftingRecipe {
 			int exclusions = buffer.readVarInt();
 			List<ResourceLocation> excludedRecipes = new ArrayList<>();
 			for(int i = 0; i < exclusions; i++) {
-				ResourceLocation loc = new ResourceLocation(buffer.readUtf(32767));
+				ResourceLocation loc = ResourceLocation.parse(buffer.readUtf(32767));
 				if(!loc.equals(recipeId))
 					excludedRecipes.add(loc);
 			}
 			String trueType = buffer.readUtf(32767);
 
-			RecipeSerializer<?> serializer = BuiltInRegistries.RECIPE_SERIALIZER.get(new ResourceLocation(trueType));
+			RecipeSerializer<?> serializer = BuiltInRegistries.RECIPE_SERIALIZER.get(ResourceLocation.parse(trueType));
 			if(serializer == null)
 				throw new IllegalArgumentException("Invalid or unsupported recipe type '" + trueType + "'");
 			Recipe<?> parent = serializer.fromNetwork(recipeId, buffer);

--- a/src/main/java/org/violetmoon/quark/content/automation/client/render/QuarkPistonBlockEntityRenderer.java
+++ b/src/main/java/org/violetmoon/quark/content/automation/client/render/QuarkPistonBlockEntityRenderer.java
@@ -38,7 +38,7 @@ public class QuarkPistonBlockEntityRenderer {
 		if(tile == null)
 			return false;
 		CompoundTag tileTag = PistonsMoveTileEntitiesModule.getMovingBlockEntityData(piston.getLevel(), truePos);
-		if(tileTag != null && tile.getType() == BuiltInRegistries.BLOCK_ENTITY_TYPE.get(new ResourceLocation(tileTag.getString("id"))))
+		if(tileTag != null && tile.getType() == BuiltInRegistries.BLOCK_ENTITY_TYPE.get(ResourceLocation.parse(tileTag.getString("id"))))
 			tile.load(tileTag);
 		Vec3 offset = new Vec3(piston.getXOff(partialTicks), piston.getYOff(partialTicks), piston.getZOff(partialTicks));
 		return renderTESafely(piston.getLevel(), truePos, state, tile, piston, partialTicks, offset, matrix, bufferIn, combinedLightIn, combinedOverlayIn);

--- a/src/main/java/org/violetmoon/quark/content/automation/module/FeedingTroughModule.java
+++ b/src/main/java/org/violetmoon/quark/content/automation/module/FeedingTroughModule.java
@@ -59,7 +59,7 @@ import java.util.*;
 public class FeedingTroughModule extends ZetaModule {
 
     //using a ResourceKey because they're interned, and Holder.Reference#is leverages this for a very efficient implementation
-    private static final ResourceKey<PoiType> FEEDING_TROUGH_POI_KEY = ResourceKey.create(Registries.POINT_OF_INTEREST_TYPE, Quark.asResource("feeding_trough"));
+    private static final ResourceKey<PoiType> FEEDING_TROUGH_POI_KEY = Quark.asResourceKey(Registries.POINT_OF_INTEREST_TYPE, "feeding_trough");
     private static final Set<FakePlayer> FREE_FAKE_PLAYERS = new HashSet<>();
     //fake players created are either stored here above or in the cache below.
     //this way each animal has its own player which is needed as they are moved in diff pos

--- a/src/main/java/org/violetmoon/quark/content/automation/module/IronRodModule.java
+++ b/src/main/java/org/violetmoon/quark/content/automation/module/IronRodModule.java
@@ -1,5 +1,6 @@
 package org.violetmoon.quark.content.automation.module;
 
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
@@ -33,6 +34,6 @@ public class IronRodModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		ironRodImmuneTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "iron_rod_immune"));
+		ironRodImmuneTag = Quark.asTagKey(Registries.BLOCK,"iron_rod_immune"));
 	}
 }

--- a/src/main/java/org/violetmoon/quark/content/automation/module/PistonsMoveTileEntitiesModule.java
+++ b/src/main/java/org/violetmoon/quark/content/automation/module/PistonsMoveTileEntitiesModule.java
@@ -299,7 +299,7 @@ public class PistonsMoveTileEntitiesModule extends ZetaModule {
 		if(inWorldEntity == null) {
 			Quark.LOG.warn("No block entity found at {} (expected {})", pos.toShortString(), expectedTypeStr);
 			return null;
-		} else if(inWorldEntity.getType() != BuiltInRegistries.BLOCK_ENTITY_TYPE.get(new ResourceLocation(expectedTypeStr))) {
+		} else if(inWorldEntity.getType() != BuiltInRegistries.BLOCK_ENTITY_TYPE.get(ResourceLocation.parse(expectedTypeStr))) {
 			Quark.LOG.warn("Wrong block entity found at {} (expected {}, got {})", pos.toShortString(), expectedTypeStr, BlockEntityType.getKey(inWorldEntity.getType()));
 			return null;
 		} else {

--- a/src/main/java/org/violetmoon/quark/content/building/client/render/be/VariantChestRenderer.java
+++ b/src/main/java/org/violetmoon/quark/content/building/client/render/be/VariantChestRenderer.java
@@ -45,7 +45,7 @@ public class VariantChestRenderer extends ChestRenderer<ChestBlockEntity> {
             else
                 tex.append(choose(type, "normal", "left", "right"));
 
-            return new Material(Sheets.CHEST_SHEET, new ResourceLocation(Quark.MOD_ID, tex.toString()));
+            return new Material(Sheets.CHEST_SHEET, Quark.asResource(tex.toString()));
         });
     }
 

--- a/src/main/java/org/violetmoon/quark/content/building/client/render/entity/GlassItemFrameRenderer.java
+++ b/src/main/java/org/violetmoon/quark/content/building/client/render/entity/GlassItemFrameRenderer.java
@@ -56,7 +56,7 @@ import java.util.List;
 
 public class GlassItemFrameRenderer extends EntityRenderer<GlassItemFrame> {
 
-	private static final ModelResourceLocation LOCATION_MODEL = new ModelResourceLocation(new ResourceLocation(Quark.MOD_ID, "extra/glass_item_frame"), "inventory");
+	private static final ModelResourceLocation LOCATION_MODEL = new ModelResourceLocation(Quark.asResource("extra/glass_item_frame"), "inventory");
 
 	private static final List<Direction> SIGN_DIRECTIONS = List.of(Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST);
 

--- a/src/main/java/org/violetmoon/quark/content/building/module/HedgesModule.java
+++ b/src/main/java/org/violetmoon/quark/content/building/module/HedgesModule.java
@@ -1,5 +1,6 @@
 package org.violetmoon.quark.content.building.module;
 
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
@@ -46,7 +47,7 @@ public class HedgesModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		hedgesTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "hedges"));
+		hedgesTag = Quark.asTagKey(Registries.BLOCK,"hedges");
 	}
 
 	@ZetaLoadModule(clientReplacement = true)

--- a/src/main/java/org/violetmoon/quark/content/building/module/HollowLogsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/building/module/HollowLogsModule.java
@@ -3,6 +3,7 @@ package org.violetmoon.quark.content.building.module;
 import java.util.HashMap;
 import java.util.Map;
 
+import net.minecraft.core.registries.Registries;
 import org.violetmoon.quark.api.ICrawlSpaceBlock;
 import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.content.building.block.HollowLogBlock;
@@ -64,7 +65,7 @@ public class HollowLogsModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		hollowLogsTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "hollow_logs"));
+		hollowLogsTag = Quark.asTagKey(Registries.BLOCK, "hollow_logs");
 	}
 
 	@PlayEvent

--- a/src/main/java/org/violetmoon/quark/content/building/module/RainbowLampsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/building/module/RainbowLampsModule.java
@@ -36,7 +36,7 @@ public class RainbowLampsModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		lampTag = Quark.asTagKey(Registries.BLOCK,"crystal_lamp");
+		lampTag = Quark.asTagKey(Registries.BLOCK, "crystal_lamp");
 	}
 
 	@LoadEvent

--- a/src/main/java/org/violetmoon/quark/content/building/module/RainbowLampsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/building/module/RainbowLampsModule.java
@@ -1,5 +1,6 @@
 package org.violetmoon.quark.content.building.module;
 
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
@@ -35,7 +36,7 @@ public class RainbowLampsModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		lampTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "crystal_lamp"));
+		lampTag = Quark.asTagKey(Registries.BLOCK,"crystal_lamp");
 	}
 
 	@LoadEvent

--- a/src/main/java/org/violetmoon/quark/content/building/module/StoolsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/building/module/StoolsModule.java
@@ -68,7 +68,7 @@ public class StoolsModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		stoolsTag = ItemTags.create(new ResourceLocation(Quark.MOD_ID, "stools"));
+		stoolsTag = Quark.asTagKey(Registries.ITEM, "stools");
 	}
 
 	@PlayEvent

--- a/src/main/java/org/violetmoon/quark/content/building/module/VariantChestsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/building/module/VariantChestsModule.java
@@ -135,11 +135,11 @@ public class VariantChestsModule extends ZetaModule {
 
 		VariantChestBlock regularChest = new VariantChestBlock(name, module, () -> chestTEType, props).setCondition(condition);
 		regularChests.add(regularChest);
-		chestMappings.put(TagKey.create(Registries.STRUCTURE, new ResourceLocation(Quark.MOD_ID, name + "_chest_structures")), regularChest);
+		chestMappings.put(Quark.asTagKey(Registries.STRUCTURE, name + "_chest_structures"), regularChest);
 
 		VariantTrappedChestBlock trappedChest = new VariantTrappedChestBlock(name, module, () -> trappedChestTEType, props).setCondition(condition);
 		trappedChests.add(trappedChest);
-		trappedChestMappings.put(TagKey.create(Registries.STRUCTURE, new ResourceLocation(Quark.MOD_ID, name + "_chest_structures")), trappedChest);
+		trappedChestMappings.put(Quark.asTagKey(Registries.STRUCTURE, name + "_chest_structures"), trappedChest);
 
 		Quark.LOOTR_INTEGRATION.makeChestBlocks(module, name, base, condition, regularChest, trappedChest);
 	}
@@ -177,12 +177,12 @@ public class VariantChestsModule extends ZetaModule {
 				String left = toks[0];
 				String right = toks[1];
 
-				Block block = BuiltInRegistries.BLOCK.get(new ResourceLocation(right));
+				Block block = BuiltInRegistries.BLOCK.get(ResourceLocation.parse(right));
 				if(block != Blocks.AIR) {
-					manualChestMappings.put(new ResourceLocation(left), block);
+					manualChestMappings.put(ResourceLocation.parse(left), block);
 					if(regularChests.contains(block)) {
 						var trapped = trappedChests.get(regularChests.indexOf(block));
-						manualTrappedChestMappings.put(new ResourceLocation(left), trapped);
+						manualTrappedChestMappings.put(ResourceLocation.parse(left), trapped);
 					}
 				}
 			}

--- a/src/main/java/org/violetmoon/quark/content/building/module/VerticalSlabsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/building/module/VerticalSlabsModule.java
@@ -111,7 +111,7 @@ public class VerticalSlabsModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		verticalSlabTag = Quark.asTagKey(Registries.BLOCK,"vertical_slabs");
+		verticalSlabTag = Quark.asTagKey(Registries.BLOCK, "vertical_slabs");
 	}
 
 	@LoadEvent

--- a/src/main/java/org/violetmoon/quark/content/building/module/VerticalSlabsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/building/module/VerticalSlabsModule.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import net.minecraft.core.registries.Registries;
 import org.apache.commons.lang3.tuple.Pair;
 import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.content.building.block.QuarkVerticalSlabBlock;
@@ -110,7 +111,7 @@ public class VerticalSlabsModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		verticalSlabTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "vertical_slabs"));
+		verticalSlabTag = Quark.asTagKey(Registries.BLOCK,"vertical_slabs");
 	}
 
 	@LoadEvent

--- a/src/main/java/org/violetmoon/quark/content/building/module/WoodenPostsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/building/module/WoodenPostsModule.java
@@ -1,5 +1,6 @@
 package org.violetmoon.quark.content.building.module;
 
+import net.minecraft.core.registries.Registries;
 import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.content.building.block.WoodPostBlock;
 import org.violetmoon.zeta.event.bus.LoadEvent;
@@ -42,7 +43,7 @@ public class WoodenPostsModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		postsTag = ItemTags.create(new ResourceLocation(Quark.MOD_ID, "posts"));
+		postsTag = Quark.asTagKey(Registries.ITEM,"posts");
 	}
 
 	public static boolean canHangingBlockConnect(BlockState state, LevelReader worldIn, BlockPos pos, boolean prev) {

--- a/src/main/java/org/violetmoon/quark/content/building/module/WoodenPostsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/building/module/WoodenPostsModule.java
@@ -1,6 +1,7 @@
 package org.violetmoon.quark.content.building.module;
 
 import net.minecraft.core.registries.Registries;
+import net.neoforged.neoforge.common.ItemAbilities;
 import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.content.building.block.WoodPostBlock;
 import org.violetmoon.zeta.event.bus.LoadEvent;
@@ -21,8 +22,6 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.LanternBlock;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.common.ToolActions;
 
 @ZetaLoadModule(category = "building")
 public class WoodenPostsModule extends ZetaModule {
@@ -37,13 +36,13 @@ public class WoodenPostsModule extends ZetaModule {
 
 			WoodPostBlock post = new WoodPostBlock(this, b, "", wood.soundWood());
 			WoodPostBlock stripped = new WoodPostBlock(this, b, "stripped_", wood.soundWood());
-			ToolInteractionHandler.registerInteraction(ToolActions.AXE_STRIP, post, stripped);
+			ToolInteractionHandler.registerInteraction(ItemAbilities.AXE_STRIP, post, stripped);
 		}
 	}
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		postsTag = Quark.asTagKey(Registries.ITEM,"posts");
+		postsTag = Quark.asTagKey(Registries.ITEM, "posts");
 	}
 
 	public static boolean canHangingBlockConnect(BlockState state, LevelReader worldIn, BlockPos pos, boolean prev) {

--- a/src/main/java/org/violetmoon/quark/content/client/module/BucketsShowInhabitantsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/client/module/BucketsShowInhabitantsModule.java
@@ -53,17 +53,17 @@ public class BucketsShowInhabitantsModule extends ZetaModule {
 		@LoadEvent
 		public void clientSetup(ZClientSetup e) {
 			e.enqueueWork(() -> {
-				ItemProperties.register(Items.AXOLOTL_BUCKET, new ResourceLocation(Quark.MOD_ID, "variant"),
+				ItemProperties.register(Items.AXOLOTL_BUCKET, Quark.asResource("variant"),
 						new MobBucketVariantProperty(Axolotl.Variant.values().length, () -> showAxolotls));
-				ItemProperties.register(CrabsModule.crab_bucket, new ResourceLocation(Quark.MOD_ID, "variant"),
+				ItemProperties.register(CrabsModule.crab_bucket, Quark.asResource("variant"),
 						new MobBucketVariantProperty(Crab.COLORS, () -> showCrabs));
 
-				ItemProperties.register(SlimeInABucketModule.slime_in_a_bucket, new ResourceLocation(Quark.MOD_ID, "shiny"),
+				ItemProperties.register(SlimeInABucketModule.slime_in_a_bucket, Quark.asResource("shiny"),
 						new ShinyMobBucketProperty(() -> showShinySlime && VariantAnimalTexturesModule.staticEnabled && VariantAnimalTexturesModule.enableShinySlime));
 
-				ItemProperties.register(Items.TROPICAL_FISH_BUCKET, new ResourceLocation(Quark.MOD_ID, "base"),
+				ItemProperties.register(Items.TROPICAL_FISH_BUCKET, Quark.asResource("base"),
 						new TropicalFishBucketVariantProperty((b) -> TropicalFish.getBaseColor(b).getId(), () -> showTropicalFish));
-				ItemProperties.register(Items.TROPICAL_FISH_BUCKET, new ResourceLocation(Quark.MOD_ID, "pattern"),
+				ItemProperties.register(Items.TROPICAL_FISH_BUCKET, Quark.asResource("pattern"),
 						new TropicalFishBucketVariantProperty((p) -> TropicalFish.getPattern(p).getPackedId(), () -> showTropicalFish));
 			});
 		}

--- a/src/main/java/org/violetmoon/quark/content/client/module/CameraModule.java
+++ b/src/main/java/org/violetmoon/quark/content/client/module/CameraModule.java
@@ -70,35 +70,35 @@ public class CameraModule extends ZetaModule {
 
 		private static final ResourceLocation[] SHADERS = new ResourceLocation[] {
 				null,
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/grayscale.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/sepia.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/desaturate.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/oversaturate.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/cool.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/warm.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/conjugate.json"),
+				Quark.asResource("shaders/post/grayscale.json"),
+				Quark.asResource("shaders/post/sepia.json"),
+				Quark.asResource("shaders/post/desaturate.json"),
+				Quark.asResource("shaders/post/oversaturate.json"),
+				Quark.asResource("shaders/post/cool.json"),
+				Quark.asResource("shaders/post/warm.json"),
+				Quark.asResource("shaders/post/conjugate.json"),
 
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/redfocus.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/greenfocus.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/bluefocus.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/yellowfocus.json"),
+				Quark.asResource("shaders/post/redfocus.json"),
+				Quark.asResource("shaders/post/greenfocus.json"),
+				Quark.asResource("shaders/post/bluefocus.json"),
+				Quark.asResource("shaders/post/yellowfocus.json"),
 
-				new ResourceLocation("shaders/post/bumpy.json"),
-				new ResourceLocation("shaders/post/notch.json"),
-				new ResourceLocation("shaders/post/creeper.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/enderman.json"),
+				ResourceLocation.withDefaultNamespace("shaders/post/bumpy.json"), //TODO this seems to not exist anymore
+				ResourceLocation.withDefaultNamespace("shaders/post/notch.json"),
+				ResourceLocation.withDefaultNamespace("shaders/post/creeper.json"),
+				Quark.asResource("shaders/post/enderman.json"),
 
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/bits.json"),
-				new ResourceLocation("shaders/post/blobs.json"),
-				new ResourceLocation("shaders/post/pencil.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/watercolor.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/monochrome.json"),
-				new ResourceLocation("shaders/post/sobel.json"),
+				Quark.asResource("shaders/post/bits.json"),
+				ResourceLocation.withDefaultNamespace("shaders/post/blobs.json"),
+				ResourceLocation.withDefaultNamespace("shaders/post/pencil.json"),
+				Quark.asResource("shaders/post/watercolor.json"),
+				Quark.asResource("shaders/post/monochrome.json"),
+				ResourceLocation.withDefaultNamespace("shaders/post/sobel.json"),
 
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/colorblind/deuteranopia.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/colorblind/protanopia.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/colorblind/tritanopia.json"),
-				new ResourceLocation(Quark.MOD_ID, "shaders/post/colorblind/achromatopsia.json")
+				Quark.asResource("shaders/post/colorblind/deuteranopia.json"),
+				Quark.asResource("shaders/post/colorblind/protanopia.json"),
+				Quark.asResource("shaders/post/colorblind/tritanopia.json"),
+				Quark.asResource("shaders/post/colorblind/achromatopsia.json")
 		};
 
 		private static KeyMapping cameraModeKey;
@@ -376,7 +376,7 @@ public class CameraModule extends ZetaModule {
 				text = I18n.get("quark.camera.info", Component.keybind("quark.keybind.camera_mode").getString());
 				guiGraphics.drawString(mc.font, text, (float) (twidth / 2 - mc.font.width(text) / 2), 16, 0xFFFFFF, true);
 
-				ResourceLocation CAMERA_TEXTURE = new ResourceLocation(Quark.MOD_ID, "textures/misc/camera.png");
+				ResourceLocation CAMERA_TEXTURE = Quark.asResource("textures/misc/camera.png");
 				RenderSystem.setShader(GameRenderer::getPositionTexShader);
 				RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
 				guiGraphics.blit(CAMERA_TEXTURE, left - 22, top + 18, 0, 0, 0, 16, 16, 16, 16);

--- a/src/main/java/org/violetmoon/quark/content/client/module/GreenerGrassModule.java
+++ b/src/main/java/org/violetmoon/quark/content/client/module/GreenerGrassModule.java
@@ -129,7 +129,7 @@ public class GreenerGrassModule extends ZetaModule {
 			BlockColors colors = Minecraft.getInstance().getBlockColors();
 
 			for(String id : ids) {
-				Block block = BuiltInRegistries.BLOCK.get(new ResourceLocation(id));
+				Block block = BuiltInRegistries.BLOCK.get(ResourceLocation.parse(id));
 				if(block == Blocks.AIR)
 					continue;
 

--- a/src/main/java/org/violetmoon/quark/content/client/module/UsesForCursesModule.java
+++ b/src/main/java/org/violetmoon/quark/content/client/module/UsesForCursesModule.java
@@ -25,7 +25,7 @@ import java.util.List;
 @ZetaLoadModule(category = "client")
 public class UsesForCursesModule extends ZetaModule {
 
-	private static final ResourceLocation PUMPKIN_OVERLAY = new ResourceLocation("textures/misc/pumpkinblur.png");
+	private static final ResourceLocation PUMPKIN_OVERLAY = ResourceLocation.withDefaultNamespace("textures/misc/pumpkinblur.png");
 
 	public static boolean staticEnabled;
 

--- a/src/main/java/org/violetmoon/quark/content/client/module/VariantAnimalTexturesModule.java
+++ b/src/main/java/org/violetmoon/quark/content/client/module/VariantAnimalTexturesModule.java
@@ -83,9 +83,9 @@ public class VariantAnimalTexturesModule extends ZetaModule {
 			textures = Multimaps.newListMultimap(new EnumMap<>(VariantTextureType.class), ArrayList::new);
 			shinyTextures = new HashMap<>();
 
-			registerTextures(VariantTextureType.COW, COW_COUNT, new ResourceLocation("textures/entity/cow/cow.png"));
-			registerTextures(VariantTextureType.PIG, PIG_COUNT, new ResourceLocation("textures/entity/pig/pig.png"));
-			registerTextures(VariantTextureType.CHICKEN, CHICKEN_COUNT, new ResourceLocation("textures/entity/chicken.png"));
+			registerTextures(VariantTextureType.COW, COW_COUNT, ResourceLocation.withDefaultNamespace("textures/entity/cow/cow.png"));
+			registerTextures(VariantTextureType.PIG, PIG_COUNT, ResourceLocation.withDefaultNamespace("textures/entity/pig/pig.png"));
+			registerTextures(VariantTextureType.CHICKEN, CHICKEN_COUNT, ResourceLocation.withDefaultNamespace("textures/entity/chicken.png"));
 			registerShiny(VariantTextureType.RABBIT);
 			registerShiny(VariantTextureType.LLAMA);
 			registerShiny(VariantTextureType.DOLPHIN);
@@ -205,7 +205,7 @@ public class VariantAnimalTexturesModule extends ZetaModule {
 						type = "nectar";
 
 					String path = String.format("textures/model/entity/variants/bees/%s/%s.png", name, type);
-					return new ResourceLocation(Quark.MOD_ID, path);
+					return Quark.asResource(path);
 				}
 			}
 
@@ -253,7 +253,7 @@ public class VariantAnimalTexturesModule extends ZetaModule {
 		private static void registerTextures(VariantTextureType type, int count, ResourceLocation vanilla) {
 			String name = type.name().toLowerCase(Locale.ROOT);
 			for(int i = 1; i < count + 1; i++)
-				textures.put(type, new ResourceLocation(Quark.MOD_ID, String.format("textures/model/entity/variants/%s%d.png", name, i)));
+				textures.put(type, Quark.asResource(String.format("textures/model/entity/variants/%s%d.png", name, i)));
 
 			if(vanilla != null)
 				textures.put(type, vanilla);
@@ -261,7 +261,7 @@ public class VariantAnimalTexturesModule extends ZetaModule {
 		}
 
 		private static void registerShiny(VariantTextureType type) {
-			shinyTextures.put(type, new ResourceLocation(Quark.MOD_ID, String.format("textures/model/entity/variants/%s_shiny.png", type.name().toLowerCase(Locale.ROOT))));
+			shinyTextures.put(type, Quark.asResource(String.format("textures/model/entity/variants/%s_shiny.png", type.name().toLowerCase(Locale.ROOT))));
 		}
 
 	}

--- a/src/main/java/org/violetmoon/quark/content/client/resources/AttributeIconEntry.java
+++ b/src/main/java/org/violetmoon/quark/content/client/resources/AttributeIconEntry.java
@@ -49,8 +49,8 @@ public record AttributeIconEntry(
 			}
 
 			String texturePath = GsonHelper.getAsString(obj, "texture");
-			ResourceLocation truncatedPath = new ResourceLocation(texturePath);
-			ResourceLocation texture = new ResourceLocation(truncatedPath.getNamespace(), "textures/" + truncatedPath.getPath() + ".png");
+			ResourceLocation truncatedPath = ResourceLocation.parse(texturePath);
+			ResourceLocation texture = ResourceLocation.fromNamespaceAndPath(truncatedPath.getNamespace(), "textures/" + truncatedPath.getPath() + ".png");
 
 			String compareStr = GsonHelper.getAsString(obj, "compare", "no_compare");
 			CompareType type = CompareType.valueOf(compareStr.toUpperCase());

--- a/src/main/java/org/violetmoon/quark/content/client/resources/AttributeTooltipManager.java
+++ b/src/main/java/org/violetmoon/quark/content/client/resources/AttributeTooltipManager.java
@@ -39,7 +39,7 @@ public class AttributeTooltipManager extends SimplePreparableReloadListener<Map<
 		Map<String, AttributeIconEntry> tooltips = new HashMap<>();
 		profiler.startTick();
 		try {
-			for(Resource resource : manager.getResourceStack(new ResourceLocation("quark", "attribute_tooltips.json"))) {
+			for(Resource resource : manager.getResourceStack(Quark.asResource("attribute_tooltips.json"))) {
 				profiler.push(resource.sourcePackId());
 
 				try {

--- a/src/main/java/org/violetmoon/quark/content/client/tooltip/AttributeTooltips.java
+++ b/src/main/java/org/violetmoon/quark/content/client/tooltip/AttributeTooltips.java
@@ -67,15 +67,15 @@ import net.minecraft.world.item.enchantment.Enchantments;
  */
 public class AttributeTooltips {
 
-	public static final ResourceLocation TEXTURE_UPGRADE = new ResourceLocation(Quark.MOD_ID, "textures/attribute/upgrade.png");
-	public static final ResourceLocation TEXTURE_DOWNGRADE = new ResourceLocation(Quark.MOD_ID, "textures/attribute/downgrade.png");
+	public static final ResourceLocation TEXTURE_UPGRADE = Quark.asResource("textures/attribute/upgrade.png");
+	public static final ResourceLocation TEXTURE_DOWNGRADE = Quark.asResource("textures/attribute/downgrade.png");
 
 	private static final Map<ResourceLocation, AttributeIconEntry> attributes = new HashMap<>();
 
 	public static void receiveAttributes(Map<String, AttributeIconEntry> map) {
 		attributes.clear();
 		for(Map.Entry<String, AttributeIconEntry> entry : map.entrySet()) {
-			attributes.put(new ResourceLocation(entry.getKey()), entry.getValue());
+			attributes.put(ResourceLocation.parse(entry.getKey()), entry.getValue());
 		}
 	}
 

--- a/src/main/java/org/violetmoon/quark/content/client/tooltip/EnchantedBookTooltips.java
+++ b/src/main/java/org/violetmoon/quark/content/client/tooltip/EnchantedBookTooltips.java
@@ -160,10 +160,10 @@ public class EnchantedBookTooltips {
 			String left = tokens[0];
 			String right = tokens[1];
 
-			BuiltInRegistries.ENCHANTMENT.getOptional(new ResourceLocation(left))
+			BuiltInRegistries.ENCHANTMENT.getOptional(ResourceLocation.parse(left))
 					.ifPresent(ench -> {
 						for(String itemId : right.split(",")) {
-							BuiltInRegistries.ITEM.getOptional(new ResourceLocation(itemId)).ifPresent(item -> additionalStacks.put(ench, new ItemStack(item)));
+							BuiltInRegistries.ITEM.getOptional(ResourceLocation.parse(itemId)).ifPresent(item -> additionalStacks.put(ench, new ItemStack(item)));
 						}
 					});
 		}

--- a/src/main/java/org/violetmoon/quark/content/client/tooltip/MapTooltips.java
+++ b/src/main/java/org/violetmoon/quark/content/client/tooltip/MapTooltips.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 public class MapTooltips {
 
-	private static final ResourceLocation RES_MAP_BACKGROUND = new ResourceLocation("textures/map/map_background.png");
+	private static final ResourceLocation RES_MAP_BACKGROUND = ResourceLocation.withDefaultNamespace("textures/map/map_background.png");
 
 	public static void makeTooltip(ZGatherTooltipComponents event) {
 		ItemStack stack = event.getItemStack();

--- a/src/main/java/org/violetmoon/quark/content/client/tooltip/ShulkerBoxTooltips.java
+++ b/src/main/java/org/violetmoon/quark/content/client/tooltip/ShulkerBoxTooltips.java
@@ -41,7 +41,7 @@ import java.util.List;
 
 public class ShulkerBoxTooltips {
 
-	public static final ResourceLocation WIDGET_RESOURCE = new ResourceLocation("quark", "textures/misc/shulker_widget.png");
+	public static final ResourceLocation WIDGET_RESOURCE = Quark.asResource("textures/misc/shulker_widget.png");
 
 	public static void makeTooltip(ZGatherTooltipComponents event) {
 		ItemStack stack = event.getItemStack();

--- a/src/main/java/org/violetmoon/quark/content/experimental/config/VariantsConfig.java
+++ b/src/main/java/org/violetmoon/quark/content/experimental/config/VariantsConfig.java
@@ -96,8 +96,8 @@ public class VariantsConfig implements IConfigType {
 		for(String s : manualVariants) {
 			String[] toks = s.split(",");
 
-			Block block = BuiltInRegistries.BLOCK.get(new ResourceLocation(toks[1]));
-			Block out = BuiltInRegistries.BLOCK.get(new ResourceLocation(toks[2]));
+			Block block = BuiltInRegistries.BLOCK.get(ResourceLocation.parse(toks[1]));
+			Block out = BuiltInRegistries.BLOCK.get(ResourceLocation.parse(toks[2]));
 			manualVariantMap.put(block, new ManualVariant(toks[0], out));
 		}
 
@@ -243,7 +243,7 @@ public class VariantsConfig implements IConfigType {
 			}
 
 		String targetStr = String.format(format, namespace, name, suffix);
-		ResourceLocation target = new ResourceLocation(targetStr);
+		ResourceLocation target = ResourceLocation.parse(targetStr);
 		Block ret = BuiltInRegistries.BLOCK.get(target);
 
 		if(ret == Blocks.AIR) {

--- a/src/main/java/org/violetmoon/quark/content/experimental/module/EnchantmentPredicatesModule.java
+++ b/src/main/java/org/violetmoon/quark/content/experimental/module/EnchantmentPredicatesModule.java
@@ -48,7 +48,7 @@ public class EnchantmentPredicatesModule extends ZetaModule {
 
 					for(Enchantment enchant : enchants) {
 						ResourceLocation enchantRes = BuiltInRegistries.ENCHANTMENT.getKey(enchant);
-						ResourceLocation name = new ResourceLocation(Quark.MOD_ID + "_has_enchant_" + enchantRes.getNamespace() + "_" + enchantRes.getPath());
+						ResourceLocation name = ResourceLocation.parse(Quark.MOD_ID + "_has_enchant_" + enchantRes.getNamespace() + "_" + enchantRes.getPath());
 						ItemPropertyFunction fun = (stack, level, entity, i) -> EnchantmentHelper.getTagEnchantmentLevel(enchant, stack);
 
 						for(Item item : items)

--- a/src/main/java/org/violetmoon/quark/content/experimental/module/EnchantmentsBegoneModule.java
+++ b/src/main/java/org/violetmoon/quark/content/experimental/module/EnchantmentsBegoneModule.java
@@ -41,7 +41,7 @@ public class EnchantmentsBegoneModule extends ZetaModule {
 		enchantments.clear();
 
 		for(String enchantKey : enchantmentsToBegone) {
-			Enchantment enchantment = BuiltInRegistries.ENCHANTMENT.get(new ResourceLocation(enchantKey));
+			Enchantment enchantment = BuiltInRegistries.ENCHANTMENT.get(ResourceLocation.parse(enchantKey));
 			if(enchantment != null)
 				enchantments.add(enchantment);
 		}

--- a/src/main/java/org/violetmoon/quark/content/experimental/module/VariantSelectorModule.java
+++ b/src/main/java/org/violetmoon/quark/content/experimental/module/VariantSelectorModule.java
@@ -418,7 +418,7 @@ public class VariantSelectorModule extends ZetaModule {
 
 					posX += width * 2;
 				} else {
-					final ResourceLocation WIDGETS_LOCATION = new ResourceLocation("textures/gui/widget.png");
+					final ResourceLocation WIDGETS_LOCATION = ResourceLocation.withDefaultNamespace("textures/gui/widget.png"); //TODO this file no longer exists
 
 					if(alignHudToHotbar) {
 						RenderSystem.enableBlend();

--- a/src/main/java/org/violetmoon/quark/content/management/client/screen/HeldShulkerBoxScreen.java
+++ b/src/main/java/org/violetmoon/quark/content/management/client/screen/HeldShulkerBoxScreen.java
@@ -24,7 +24,7 @@ import org.violetmoon.quark.content.management.inventory.HeldShulkerBoxMenu;
 
 public class HeldShulkerBoxScreen extends AbstractContainerScreen<HeldShulkerBoxMenu> implements IQuarkButtonAllowed {
 
-	private static final ResourceLocation CONTAINER_TEXTURE = new ResourceLocation("textures/gui/container/shulker_box.png");
+	private static final ResourceLocation CONTAINER_TEXTURE = ResourceLocation.withDefaultNamespace("textures/gui/container/shulker_box.png");
 
 	public HeldShulkerBoxScreen(HeldShulkerBoxMenu p_99240_, Inventory p_99241_, Component p_99242_) {
 		super(p_99240_, p_99241_, p_99242_);

--- a/src/main/java/org/violetmoon/quark/content/management/module/HotbarChangerModule.java
+++ b/src/main/java/org/violetmoon/quark/content/management/module/HotbarChangerModule.java
@@ -32,7 +32,7 @@ import org.violetmoon.zeta.module.ZetaModule;
 
 @ZetaLoadModule(category = "management")
 public class HotbarChangerModule extends ZetaModule {
-	private static final ResourceLocation WIDGETS = new ResourceLocation("textures/gui/widgets.png");
+	private static final ResourceLocation WIDGETS = ResourceLocation.withDefaultNamespace("textures/gui/widgets.png"); //TODO this file no longer exists
 
 	private static final int MAX_HEIGHT = 90;
 

--- a/src/main/java/org/violetmoon/quark/content/mobs/client/layer/CrabMoldLayer.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/client/layer/CrabMoldLayer.java
@@ -15,7 +15,7 @@ import org.violetmoon.quark.content.mobs.entity.Crab;
 
 public class CrabMoldLayer extends RenderLayer<Crab, CrabModel> {
 
-	private static final ResourceLocation MOLD_LAYER = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/crab/mold_layer.png");
+	private static final ResourceLocation MOLD_LAYER = Quark.asResource("textures/model/entity/crab/mold_layer.png");
 
 	public CrabMoldLayer(RenderLayerParent<Crab, CrabModel> renderer) {
 		super(renderer);

--- a/src/main/java/org/violetmoon/quark/content/mobs/client/layer/FoxhoundCollarLayer.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/client/layer/FoxhoundCollarLayer.java
@@ -25,7 +25,7 @@ import org.violetmoon.quark.content.mobs.entity.Foxhound;
 
 public class FoxhoundCollarLayer extends RenderLayer<Foxhound, FoxhoundModel> {
 
-	private static final ResourceLocation WOLF_COLLAR = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/foxhound/collar.png");
+	private static final ResourceLocation WOLF_COLLAR = Quark.asResource("textures/model/entity/foxhound/collar.png");
 
 	public FoxhoundCollarLayer(RenderLayerParent<Foxhound, FoxhoundModel> renderer) {
 		super(renderer);

--- a/src/main/java/org/violetmoon/quark/content/mobs/client/layer/StonelingLichenLayer.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/client/layer/StonelingLichenLayer.java
@@ -15,7 +15,7 @@ import org.violetmoon.quark.content.mobs.entity.Stoneling;
 
 public class StonelingLichenLayer extends RenderLayer<Stoneling, StonelingModel> {
 
-	private static final ResourceLocation MOLD_LAYER = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/stoneling/lichen_layer.png");
+	private static final ResourceLocation MOLD_LAYER = Quark.asResource("textures/model/entity/stoneling/lichen_layer.png");
 
 	public StonelingLichenLayer(RenderLayerParent<Stoneling, StonelingModel> renderer) {
 		super(renderer);

--- a/src/main/java/org/violetmoon/quark/content/mobs/client/layer/ToretoiseOreLayer.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/client/layer/ToretoiseOreLayer.java
@@ -25,7 +25,7 @@ public class ToretoiseOreLayer extends RenderLayer<Toretoise, ToretoiseModel> {
 	public void render(@NotNull PoseStack matrix, @NotNull MultiBufferSource buffer, int light, Toretoise entity, float limbAngle, float limbDistance, float tickDelta, float customAngle, float headYaw, float headPitch) {
 		int ore = entity.getOreType();
 		if(ore != 0 && ore <= Toretoise.ORE_TYPES) {
-			ResourceLocation res = new ResourceLocation(String.format(ORE_BASE, ore));
+			ResourceLocation res = ResourceLocation.parse(String.format(ORE_BASE, ore));
 			renderColoredCutoutModel(getParentModel(), res, matrix, buffer, light, entity, 1, 1, 1);
 		}
 	}

--- a/src/main/java/org/violetmoon/quark/content/mobs/client/layer/forgotten/ForgottenClothingLayer.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/client/layer/forgotten/ForgottenClothingLayer.java
@@ -19,7 +19,7 @@ import org.violetmoon.quark.base.Quark;
 
 public class ForgottenClothingLayer<T extends Mob & RangedAttackMob, M extends EntityModel<T>> extends RenderLayer<T, M> {
 
-	private static final ResourceLocation TEXTURE = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/forgotten/overlay.png");
+	private static final ResourceLocation TEXTURE = Quark.asResource("textures/model/entity/forgotten/overlay.png");
 	private final SkeletonModel<T> layerModel;
 
 	public ForgottenClothingLayer(RenderLayerParent<T, M> parent, EntityModelSet model) {

--- a/src/main/java/org/violetmoon/quark/content/mobs/client/layer/forgotten/ForgottenEyesLayer.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/client/layer/forgotten/ForgottenEyesLayer.java
@@ -13,7 +13,7 @@ import org.violetmoon.quark.base.Quark;
 
 public class ForgottenEyesLayer<T extends Skeleton, M extends SkeletonModel<T>> extends EyesLayer<T, M> {
 
-	private static final ResourceLocation TEXTURE = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/forgotten/eye.png");
+	private static final ResourceLocation TEXTURE = Quark.asResource("textures/model/entity/forgotten/eye.png");
 	private static final RenderType RENDER_TYPE = RenderType.eyes(TEXTURE);
 
 	public ForgottenEyesLayer(RenderLayerParent<T, M> rendererIn) {

--- a/src/main/java/org/violetmoon/quark/content/mobs/client/layer/shiba/ShibaCollarLayer.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/client/layer/shiba/ShibaCollarLayer.java
@@ -25,7 +25,7 @@ import org.violetmoon.quark.content.mobs.entity.Shiba;
 
 public class ShibaCollarLayer extends RenderLayer<Shiba, ShibaModel> {
 
-	private static final ResourceLocation WOLF_COLLAR = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/shiba/collar.png");
+	private static final ResourceLocation WOLF_COLLAR = Quark.asResource("textures/model/entity/shiba/collar.png");
 
 	public ShibaCollarLayer(RenderLayerParent<Shiba, ShibaModel> renderer) {
 		super(renderer);

--- a/src/main/java/org/violetmoon/quark/content/mobs/client/render/entity/CrabRenderer.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/client/render/entity/CrabRenderer.java
@@ -6,6 +6,7 @@ import net.minecraft.resources.ResourceLocation;
 
 import org.jetbrains.annotations.NotNull;
 
+import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.base.client.handler.ModelHandler;
 import org.violetmoon.quark.content.mobs.client.layer.CrabMoldLayer;
 import org.violetmoon.quark.content.mobs.client.model.CrabModel;
@@ -14,9 +15,9 @@ import org.violetmoon.quark.content.mobs.entity.Crab;
 public class CrabRenderer extends MobRenderer<Crab, CrabModel> {
 
 	private static final ResourceLocation[] TEXTURES = new ResourceLocation[] {
-			new ResourceLocation("quark", "textures/model/entity/crab/red.png"),
-			new ResourceLocation("quark", "textures/model/entity/crab/blue.png"),
-			new ResourceLocation("quark", "textures/model/entity/crab/green.png")
+			Quark.asResource("textures/model/entity/crab/red.png"),
+			Quark.asResource("textures/model/entity/crab/blue.png"),
+			Quark.asResource("textures/model/entity/crab/green.png")
 	};
 
 	public CrabRenderer(EntityRendererProvider.Context context) {

--- a/src/main/java/org/violetmoon/quark/content/mobs/client/render/entity/ForgottenRenderer.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/client/render/entity/ForgottenRenderer.java
@@ -16,7 +16,7 @@ import org.violetmoon.quark.content.mobs.client.layer.forgotten.ForgottenSheathe
 
 public class ForgottenRenderer extends SkeletonRenderer {
 
-	private static final ResourceLocation TEXTURE = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/forgotten/main.png");
+	private static final ResourceLocation TEXTURE = Quark.asResource("textures/model/entity/forgotten/main.png");
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public ForgottenRenderer(EntityRendererProvider.Context context) {

--- a/src/main/java/org/violetmoon/quark/content/mobs/client/render/entity/FoxhoundRenderer.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/client/render/entity/FoxhoundRenderer.java
@@ -26,17 +26,17 @@ import java.util.UUID;
 
 public class FoxhoundRenderer extends MobRenderer<Foxhound, FoxhoundModel> {
 
-	private static final ResourceLocation FOXHOUND_IDLE = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/foxhound/red/idle.png");
-	private static final ResourceLocation FOXHOUND_HOSTILE = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/foxhound/red/hostile.png");
-	private static final ResourceLocation FOXHOUND_SLEEPING = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/foxhound/red/sleeping.png");
+	private static final ResourceLocation FOXHOUND_IDLE = Quark.asResource("textures/model/entity/foxhound/red/idle.png");
+	private static final ResourceLocation FOXHOUND_HOSTILE = Quark.asResource("textures/model/entity/foxhound/red/hostile.png");
+	private static final ResourceLocation FOXHOUND_SLEEPING = Quark.asResource("textures/model/entity/foxhound/red/sleeping.png");
 
-	private static final ResourceLocation SOULHOUND_IDLE = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/foxhound/blue/idle.png");
-	private static final ResourceLocation SOULHOUND_HOSTILE = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/foxhound/blue/hostile.png");
-	private static final ResourceLocation SOULHOUND_SLEEPING = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/foxhound/blue/sleeping.png");
+	private static final ResourceLocation SOULHOUND_IDLE = Quark.asResource("textures/model/entity/foxhound/blue/idle.png");
+	private static final ResourceLocation SOULHOUND_HOSTILE = Quark.asResource("textures/model/entity/foxhound/blue/hostile.png");
+	private static final ResourceLocation SOULHOUND_SLEEPING = Quark.asResource("textures/model/entity/foxhound/blue/sleeping.png");
 
-	private static final ResourceLocation BASALT_FOXHOUND_IDLE = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/foxhound/black/idle.png");
-	private static final ResourceLocation BASALT_FOXHOUND_HOSTILE = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/foxhound/black/hostile.png");
-	private static final ResourceLocation BASALT_FOXHOUND_SLEEPING = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/foxhound/black/sleeping.png");
+	private static final ResourceLocation BASALT_FOXHOUND_IDLE = Quark.asResource("textures/model/entity/foxhound/black/idle.png");
+	private static final ResourceLocation BASALT_FOXHOUND_HOSTILE = Quark.asResource("textures/model/entity/foxhound/black/hostile.png");
+	private static final ResourceLocation BASALT_FOXHOUND_SLEEPING = Quark.asResource("textures/model/entity/foxhound/black/sleeping.png");
 
 	private static final int SHINY_CHANCE = 256;
 

--- a/src/main/java/org/violetmoon/quark/content/mobs/client/render/entity/ShibaRenderer.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/client/render/entity/ShibaRenderer.java
@@ -16,13 +16,13 @@ import org.violetmoon.quark.content.mobs.entity.Shiba;
 public class ShibaRenderer extends MobRenderer<Shiba, ShibaModel> {
 
 	private static final ResourceLocation[] SHIBA_BASES = {
-			new ResourceLocation(Quark.MOD_ID, "textures/model/entity/shiba/shiba0.png"),
-			new ResourceLocation(Quark.MOD_ID, "textures/model/entity/shiba/shiba1.png"),
-			new ResourceLocation(Quark.MOD_ID, "textures/model/entity/shiba/shiba2.png")
+			Quark.asResource("textures/model/entity/shiba/shiba0.png"),
+			Quark.asResource("textures/model/entity/shiba/shiba1.png"),
+			Quark.asResource("textures/model/entity/shiba/shiba2.png")
 	};
 
-	private static final ResourceLocation SHIBA_RARE = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/shiba/shiba_rare.png");
-	private static final ResourceLocation SHIBA_DOGE = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/shiba/shiba_doge.png");
+	private static final ResourceLocation SHIBA_RARE = Quark.asResource("textures/model/entity/shiba/shiba_rare.png");
+	private static final ResourceLocation SHIBA_DOGE = Quark.asResource("textures/model/entity/shiba/shiba_doge.png");
 
 	public ShibaRenderer(EntityRendererProvider.Context context) {
 		super(context, ModelHandler.model(ModelHandler.shiba), 0.5F);

--- a/src/main/java/org/violetmoon/quark/content/mobs/client/render/entity/ToretoiseRenderer.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/client/render/entity/ToretoiseRenderer.java
@@ -14,7 +14,7 @@ import org.violetmoon.quark.content.mobs.entity.Toretoise;
 
 public class ToretoiseRenderer extends MobRenderer<Toretoise, ToretoiseModel> {
 
-	private static final ResourceLocation BASE_TEXTURE = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/toretoise/base.png");
+	private static final ResourceLocation BASE_TEXTURE = Quark.asResource("textures/model/entity/toretoise/base.png");
 
 	public ToretoiseRenderer(EntityRendererProvider.Context context) {
 		super(context, ModelHandler.model(ModelHandler.toretoise), 1F);

--- a/src/main/java/org/violetmoon/quark/content/mobs/client/render/entity/WraithRenderer.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/client/render/entity/WraithRenderer.java
@@ -6,13 +6,14 @@ import net.minecraft.resources.ResourceLocation;
 
 import org.jetbrains.annotations.NotNull;
 
+import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.base.client.handler.ModelHandler;
 import org.violetmoon.quark.content.mobs.client.model.WraithModel;
 import org.violetmoon.quark.content.mobs.entity.Wraith;
 
 public class WraithRenderer extends MobRenderer<Wraith, WraithModel> {
 
-	private static final ResourceLocation TEXTURE = new ResourceLocation("quark", "textures/model/entity/wraith.png");
+	private static final ResourceLocation TEXTURE = Quark.asResource("textures/model/entity/wraith.png");
 
 	public WraithRenderer(EntityRendererProvider.Context context) {
 		super(context, ModelHandler.model(ModelHandler.wraith), 0F);

--- a/src/main/java/org/violetmoon/quark/content/mobs/entity/Crab.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/entity/Crab.java
@@ -12,6 +12,7 @@ package org.violetmoon.quark.content.mobs.entity;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.Packet;
@@ -19,6 +20,7 @@ import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
@@ -54,6 +56,7 @@ import net.minecraft.world.level.block.LevelEvent;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.gameevent.*;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
+import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.ForgeMod;
@@ -74,7 +77,7 @@ import java.util.function.BiConsumer;
 public class Crab extends Animal implements IEntityAdditionalSpawnData, Bucketable {
 
 	public static final int COLORS = 3;
-	public static final ResourceLocation CRAB_LOOT_TABLE = new ResourceLocation("quark", "entities/crab");
+	public static final ResourceKey<LootTable> CRAB_LOOT_TABLE = Quark.asResourceKey(Registries.LOOT_TABLE, "entities/crab");
 
 	private static final EntityDataAccessor<Float> SIZE_MODIFIER = SynchedEntityData.defineId(Crab.class, EntityDataSerializers.FLOAT);
 	private static final EntityDataAccessor<Integer> VARIANT = SynchedEntityData.defineId(Crab.class, EntityDataSerializers.INT);
@@ -413,7 +416,7 @@ public class Crab extends Animal implements IEntityAdditionalSpawnData, Bucketab
 	private Ingredient getTemptationItems() {
 		if(temptationItems == null)
 			temptationItems = Ingredient.of(
-					ItemTags.create(new ResourceLocation(Quark.MOD_ID, "crab_tempt_items")));
+					Quark.asTagKey(Registries.ITEM,"crab_tempt_items"));
 
 		return temptationItems;
 	}
@@ -424,9 +427,8 @@ public class Crab extends Animal implements IEntityAdditionalSpawnData, Bucketab
 		return new Crab(CrabsModule.crabType, level());
 	}
 
-	@NotNull
 	@Override
-	protected ResourceLocation getDefaultLootTable() {
+	protected ResourceKey<LootTable> getDefaultLootTable() {
 		return CRAB_LOOT_TABLE;
 	}
 

--- a/src/main/java/org/violetmoon/quark/content/mobs/entity/Crab.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/entity/Crab.java
@@ -416,7 +416,7 @@ public class Crab extends Animal implements IEntityAdditionalSpawnData, Bucketab
 	private Ingredient getTemptationItems() {
 		if(temptationItems == null)
 			temptationItems = Ingredient.of(
-					Quark.asTagKey(Registries.ITEM,"crab_tempt_items"));
+					Quark.asTagKey(Registries.ITEM, "crab_tempt_items"));
 
 		return temptationItems;
 	}

--- a/src/main/java/org/violetmoon/quark/content/mobs/entity/Forgotten.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/entity/Forgotten.java
@@ -2,12 +2,14 @@ package org.violetmoon.quark.content.mobs.entity;
 
 import com.google.common.collect.ImmutableSet;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.DifficultyInstance;
@@ -34,6 +36,7 @@ import net.minecraft.world.item.alchemy.PotionUtils;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.ServerLevelAccessor;
+import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -48,7 +51,7 @@ public class Forgotten extends Skeleton {
 
 	public static final EntityDataAccessor<ItemStack> SHEATHED_ITEM = SynchedEntityData.defineId(Forgotten.class, EntityDataSerializers.ITEM_STACK);
 
-	public static final ResourceLocation FORGOTTEN_LOOT_TABLE = new ResourceLocation("quark", "entities/forgotten");
+	public static final ResourceKey<LootTable> FORGOTTEN_LOOT_TABLE = Quark.asResourceKey(Registries.LOOT_TABLE, "entities/forgotten");
 
 	public Forgotten(EntityType<? extends Forgotten> type, Level world) {
 		super(type, world);
@@ -113,9 +116,8 @@ public class Forgotten extends Skeleton {
 		reassessWeaponGoal();
 	}
 
-	@NotNull
 	@Override
-	protected ResourceLocation getDefaultLootTable() {
+	protected ResourceKey<LootTable> getDefaultLootTable() {
 		return FORGOTTEN_LOOT_TABLE;
 	}
 

--- a/src/main/java/org/violetmoon/quark/content/mobs/entity/Foxhound.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/entity/Foxhound.java
@@ -14,12 +14,14 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.particles.SimpleParticleType;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -54,6 +56,7 @@ import net.minecraft.world.level.biome.Biomes;
 import net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
+import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.network.NetworkHooks;
@@ -62,6 +65,7 @@ import org.jetbrains.annotations.NotNull;
 
 import org.violetmoon.quark.addons.oddities.block.TinyPotatoBlock;
 import org.violetmoon.quark.addons.oddities.module.TinyPotatoModule;
+import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.base.handler.QuarkSounds;
 import org.violetmoon.quark.content.mobs.ai.FindPlaceToSleepGoal;
 import org.violetmoon.quark.content.mobs.ai.SleepGoal;
@@ -77,7 +81,7 @@ import static org.violetmoon.quark.content.mobs.ai.FindPlaceToSleepGoal.Target.*
 
 public class Foxhound extends Wolf implements Enemy {
 
-	public static final ResourceLocation FOXHOUND_LOOT_TABLE = new ResourceLocation("quark", "entities/foxhound");
+	public static final ResourceKey<LootTable> FOXHOUND_LOOT_TABLE = Quark.asResourceKey(Registries.LOOT_TABLE,"entities/foxhound");
 
 	private static final EntityDataAccessor<Boolean> TEMPTATION = SynchedEntityData.defineId(Foxhound.class, EntityDataSerializers.BOOLEAN);
 	private static final EntityDataAccessor<Boolean> IS_BLUE = SynchedEntityData.defineId(Foxhound.class, EntityDataSerializers.BOOLEAN);
@@ -222,9 +226,8 @@ public class Foxhound extends Wolf implements Enemy {
 		return false;
 	}
 
-	@NotNull
 	@Override
-	protected ResourceLocation getDefaultLootTable() {
+	protected ResourceKey<LootTable> getDefaultLootTable() {
 		return FOXHOUND_LOOT_TABLE;
 	}
 

--- a/src/main/java/org/violetmoon/quark/content/mobs/entity/Foxhound.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/entity/Foxhound.java
@@ -81,7 +81,7 @@ import static org.violetmoon.quark.content.mobs.ai.FindPlaceToSleepGoal.Target.*
 
 public class Foxhound extends Wolf implements Enemy {
 
-	public static final ResourceKey<LootTable> FOXHOUND_LOOT_TABLE = Quark.asResourceKey(Registries.LOOT_TABLE,"entities/foxhound");
+	public static final ResourceKey<LootTable> FOXHOUND_LOOT_TABLE = Quark.asResourceKey(Registries.LOOT_TABLE, "entities/foxhound");
 
 	private static final EntityDataAccessor<Boolean> TEMPTATION = SynchedEntityData.defineId(Foxhound.class, EntityDataSerializers.BOOLEAN);
 	private static final EntityDataAccessor<Boolean> IS_BLUE = SynchedEntityData.defineId(Foxhound.class, EntityDataSerializers.BOOLEAN);

--- a/src/main/java/org/violetmoon/quark/content/mobs/entity/Stoneling.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/entity/Stoneling.java
@@ -5,12 +5,14 @@ import com.google.common.collect.Sets;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.BlockParticleOption;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
@@ -39,6 +41,7 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
 import net.minecraft.world.level.storage.loot.LootParams;
+import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.HitResult;
@@ -67,7 +70,7 @@ import static org.violetmoon.quark.content.world.module.NewStoneTypesModule.*;
 
 public class Stoneling extends PathfinderMob {
 
-	public static final ResourceLocation CARRY_LOOT_TABLE = new ResourceLocation("quark", "entities/stoneling_carry");
+	public static final ResourceKey<LootTable> CARRY_LOOT_TABLE = Quark.asResourceKey(Registries.LOOT_TABLE, "entities/stoneling_carry");
 
 	private static final EntityDataAccessor<ItemStack> CARRYING_ITEM = SynchedEntityData.defineId(Stoneling.class, EntityDataSerializers.ITEM_STACK);
 	private static final EntityDataAccessor<Byte> VARIANT = SynchedEntityData.defineId(Stoneling.class, EntityDataSerializers.BYTE);
@@ -263,7 +266,7 @@ public class Stoneling extends PathfinderMob {
 		entityData.set(HOLD_ANGLE, world.getRandom().nextFloat() * 90 - 45);
 
 		if(!isTame && !world.isClientSide()) {
-			List<ItemStack> items = world.getServer().getLootData()
+			List<ItemStack> items = world.getServer().reloadableRegistries()
 					.getLootTable(CARRY_LOOT_TABLE).getRandomItems(new LootParams.Builder(world.getLevel())
 							.withParameter(LootContextParams.ORIGIN, position())
 							.create(LootContextParamSets.CHEST));
@@ -506,7 +509,7 @@ public class Stoneling extends PathfinderMob {
 		private final List<Block> blocks;
 
 		StonelingVariant(String variantPath, Block... blocks) {
-			this.texture = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/stoneling/" + variantPath + ".png");
+			this.texture = Quark.asResource("textures/model/entity/stoneling/" + variantPath + ".png");
 			this.blocks = Lists.newArrayList(blocks);
 		}
 

--- a/src/main/java/org/violetmoon/quark/content/mobs/entity/Toretoise.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/entity/Toretoise.java
@@ -53,7 +53,7 @@ import java.util.List;
 
 public class Toretoise extends Animal {
 
-	private static final TagKey<Block> BREAKS_TORETOISE_ORE = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "breaks_toretoise_ore"));
+	private static final TagKey<Block> BREAKS_TORETOISE_ORE = BlockTags.create(Quark.asResource("breaks_toretoise_ore"));
 
 	public static final int ORE_TYPES = 5;
 	public static final int ANGERY_TIME = 20;
@@ -105,7 +105,7 @@ public class Toretoise extends Animal {
 
 	private void computeGoodFood() {
 		goodFood = Ingredient.of(ToretoiseModule.foods.stream()
-				.map(loc -> BuiltInRegistries.ITEM.get(new ResourceLocation(loc)))
+				.map(loc -> BuiltInRegistries.ITEM.get(ResourceLocation.parse(loc)))
 				.filter(i -> i != Items.AIR)
 				.map(ItemStack::new));
 	}

--- a/src/main/java/org/violetmoon/quark/content/mobs/entity/Wraith.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/entity/Wraith.java
@@ -3,10 +3,12 @@ package org.violetmoon.quark.content.mobs.entity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
@@ -29,16 +31,18 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.ServerLevelAccessor;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 
 import org.jetbrains.annotations.NotNull;
 
+import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.content.mobs.module.WraithModule;
 
 public class Wraith extends Zombie {
 
-	public static final ResourceLocation LOOT_TABLE = new ResourceLocation("quark:entities/wraith");
+	public static final ResourceKey<LootTable> LOOT_TABLE = Quark.asResourceKey(Registries.LOOT_TABLE, "entities/wraith");
 
 	private static final EntityDataAccessor<String> IDLE_SOUND = SynchedEntityData.defineId(Wraith.class, EntityDataSerializers.STRING);
 	private static final EntityDataAccessor<String> HURT_SOUND = SynchedEntityData.defineId(Wraith.class, EntityDataSerializers.STRING);
@@ -99,7 +103,7 @@ public class Wraith extends Zombie {
 	}
 
 	public SoundEvent getSound(EntityDataAccessor<String> param) {
-		ResourceLocation loc = new ResourceLocation(entityData.get(param));
+		ResourceLocation loc = ResourceLocation.parse(entityData.get(param));
 		return BuiltInRegistries.SOUND_EVENT.get(loc);
 	}
 
@@ -173,9 +177,8 @@ public class Wraith extends Zombie {
 		entityData.set(DEATH_SOUND, compound.getString(TAG_DEATH_SOUND));
 	}
 
-	@NotNull
 	@Override
-	protected ResourceLocation getDefaultLootTable() {
+	protected ResourceKey<LootTable> getDefaultLootTable() {
 		return LOOT_TABLE;
 	}
 

--- a/src/main/java/org/violetmoon/quark/content/mobs/module/CrabsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/module/CrabsModule.java
@@ -150,7 +150,7 @@ public class CrabsModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		crabSpawnableTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "crab_spawnable"));
+		crabSpawnableTag = Quark.asTagKey(Registries.BLOCK,"crab_spawnable");
 	}
 
 	@ZetaLoadModule(clientReplacement = true)

--- a/src/main/java/org/violetmoon/quark/content/mobs/module/FoxhoundModule.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/module/FoxhoundModule.java
@@ -95,7 +95,7 @@ public class FoxhoundModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		foxhoundSpawnableTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "foxhound_spawnable"));
+		foxhoundSpawnableTag = BlockTags.create(Quark.asResource("foxhound_spawnable"));
 	}
 
 	@PlayEvent

--- a/src/main/java/org/violetmoon/quark/content/mobs/module/WraithModule.java
+++ b/src/main/java/org/violetmoon/quark/content/mobs/module/WraithModule.java
@@ -116,8 +116,8 @@ public class WraithModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		wraithSpawnableTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "wraith_spawnable"));
-		soulBeadTargetTag = TagKey.create(Registries.STRUCTURE, new ResourceLocation(Quark.MOD_ID, "soul_bead_target"));
+		wraithSpawnableTag = Quark.asTagKey(Registries.BLOCK,"wraith_spawnable");
+		soulBeadTargetTag = Quark.asTagKey(Registries.STRUCTURE,"soul_bead_target");
 	}
 
 

--- a/src/main/java/org/violetmoon/quark/content/tools/client/render/GlintRenderTypes.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/client/render/GlintRenderTypes.java
@@ -145,6 +145,6 @@ public class GlintRenderTypes extends RenderType {
 	}
 
 	private static ResourceLocation texture(String name) {
-		return new ResourceLocation(Quark.MOD_ID, "textures/glint/enchanted_item_glint_" + name + ".png");
+		return Quark.asResource("textures/glint/enchanted_item_glint_" + name + ".png");
 	}
 }

--- a/src/main/java/org/violetmoon/quark/content/tools/client/render/entity/TorchArrowRenderer.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/client/render/entity/TorchArrowRenderer.java
@@ -9,7 +9,7 @@ import org.violetmoon.quark.content.tools.entity.TorchArrow;
 
 public class TorchArrowRenderer extends ArrowRenderer<TorchArrow> {
 
-	public static final ResourceLocation TORCH_ARROW_LOCATION = new ResourceLocation(Quark.MOD_ID, "textures/model/entity/torch_arrow.png");
+	public static final ResourceLocation TORCH_ARROW_LOCATION = Quark.asResource("textures/model/entity/torch_arrow.png");
 
 	public TorchArrowRenderer(EntityRendererProvider.Context p_174399_) {
 		super(p_174399_);
@@ -17,7 +17,7 @@ public class TorchArrowRenderer extends ArrowRenderer<TorchArrow> {
 
 	@Override
 	public ResourceLocation getTextureLocation(TorchArrow p_116001_) {
-		return new ResourceLocation(Quark.MOD_ID, "textures/model/entity/torch_arrow.png");
+		return TORCH_ARROW_LOCATION;
 	}
 
 }

--- a/src/main/java/org/violetmoon/quark/content/tools/item/PathfindersQuillItem.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/item/PathfindersQuillItem.java
@@ -86,7 +86,7 @@ public class PathfindersQuillItem extends ZetaItem implements CreativeTabManager
 		if(str.isEmpty())
 			return null;
 
-		return new ResourceLocation(str);
+		return ResourceLocation.parse(str);
 	}
 
 	public static int getOverlayColor(ItemStack stack) {

--- a/src/main/java/org/violetmoon/quark/content/tools/item/RuneItem.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/item/RuneItem.java
@@ -22,15 +22,15 @@ import java.util.List;
  */
 public class RuneItem extends ZetaSmithingTemplateItem implements IRuneColorProvider {
 
-	private static final Component RUNE_APPLIES_TO = Component.translatable(Util.makeDescriptionId("item", new ResourceLocation(Quark.MOD_ID, "smithing_template.rune.applies_to"))).withStyle(Z_DESCRIPTION_FORMAT);
-	private static final Component RUNE_INGREDIENTS = Component.translatable(Util.makeDescriptionId("item", new ResourceLocation(Quark.MOD_ID, "smithing_template.rune.ingredients"))).withStyle(Z_DESCRIPTION_FORMAT);
-	private static final Component RUNE_UPGRADE = Component.translatable(Util.makeDescriptionId("upgrade", new ResourceLocation(Quark.MOD_ID, "rune_upgrade"))).withStyle(Z_TITLE_FORMAT);
-	private static final Component RUNE_BASE_SLOT_DESCRIPTION = Component.translatable(Util.makeDescriptionId("item", new ResourceLocation(Quark.MOD_ID, "smithing_template.rune.base_slot_description")));
-	private static final Component RUNE_ADDITIONS_SLOT_DESCRIPTION = Component.translatable(Util.makeDescriptionId("item", new ResourceLocation(Quark.MOD_ID, "smithing_template.rune.additions_slot_description")));
+	private static final Component RUNE_APPLIES_TO = Component.translatable(Util.makeDescriptionId("item", Quark.asResource("smithing_template.rune.applies_to"))).withStyle(Z_DESCRIPTION_FORMAT);
+	private static final Component RUNE_INGREDIENTS = Component.translatable(Util.makeDescriptionId("item", Quark.asResource("smithing_template.rune.ingredients"))).withStyle(Z_DESCRIPTION_FORMAT);
+	private static final Component RUNE_UPGRADE = Component.translatable(Util.makeDescriptionId("upgrade", Quark.asResource("rune_upgrade"))).withStyle(Z_TITLE_FORMAT);
+	private static final Component RUNE_BASE_SLOT_DESCRIPTION = Component.translatable(Util.makeDescriptionId("item", Quark.asResource("smithing_template.rune.base_slot_description")));
+	private static final Component RUNE_ADDITIONS_SLOT_DESCRIPTION = Component.translatable(Util.makeDescriptionId("item", Quark.asResource("smithing_template.rune.additions_slot_description")));
 
-	private static final ResourceLocation EMPTY_SLOT_BLAZE_POWDER = new ResourceLocation(Quark.MOD_ID, "item/empty_slot_blaze_powder");
-	private static final ResourceLocation EMPTY_SLOT_DYE = new ResourceLocation(Quark.MOD_ID, "item/empty_slot_dye");
-	private static final ResourceLocation EMPTY_SLOT_NOTHING = new ResourceLocation(Quark.MOD_ID, "item/empty_slot_nothing");
+	private static final ResourceLocation EMPTY_SLOT_BLAZE_POWDER = Quark.asResource("item/empty_slot_blaze_powder");
+	private static final ResourceLocation EMPTY_SLOT_DYE = Quark.asResource("item/empty_slot_dye");
+	private static final ResourceLocation EMPTY_SLOT_NOTHING = Quark.asResource("item/empty_slot_nothing");
 
 	public RuneItem(String regname, ZetaModule module) {
 		super(regname, module, RUNE_APPLIES_TO, RUNE_INGREDIENTS, RUNE_UPGRADE, RUNE_BASE_SLOT_DESCRIPTION, RUNE_ADDITIONS_SLOT_DESCRIPTION, anyToolIconList(),

--- a/src/main/java/org/violetmoon/quark/content/tools/loot/InBiomeCondition.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/loot/InBiomeCondition.java
@@ -42,7 +42,7 @@ public record InBiomeCondition(ResourceLocation target) implements LootItemCondi
 		@NotNull
 		public InBiomeCondition deserialize(@NotNull JsonObject object, @NotNull JsonDeserializationContext deserializationContext) {
 			String key = GsonHelper.getAsString(object, "target");
-			ResourceLocation target = new ResourceLocation(key);
+			ResourceLocation target = ResourceLocation.parse(key);
 
 			return new InBiomeCondition(target);
 		}

--- a/src/main/java/org/violetmoon/quark/content/tools/module/AbacusModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/module/AbacusModule.java
@@ -23,6 +23,7 @@ import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
 import org.joml.Matrix4f;
+import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.base.config.type.RGBAColorConfig;
 import org.violetmoon.quark.content.tools.item.AbacusItem;
 import org.violetmoon.zeta.client.event.load.ZClientSetup;
@@ -57,7 +58,7 @@ public class AbacusModule extends ZetaModule {
 
 		@LoadEvent
 		public void clientSetup(ZClientSetup e) {
-			e.enqueueWork(() -> ItemProperties.register(abacus, new ResourceLocation("count"), AbacusItem.Client.ITEM_PROPERTY_FUNCTION));
+			e.enqueueWork(() -> ItemProperties.register(abacus, Quark.asResource("count"), AbacusItem.Client.ITEM_PROPERTY_FUNCTION));
 		}
 
 		@PlayEvent

--- a/src/main/java/org/violetmoon/quark/content/tools/module/AncientTomesModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/module/AncientTomesModule.java
@@ -141,7 +141,7 @@ public class AncientTomesModule extends ZetaModule {
 		ancient_tome = new AncientTomeItem(this);
 
 		tomeEnchantType = new LootItemFunctionType(new EnchantTome.Serializer());
-		Registry.register(BuiltInRegistries.LOOT_FUNCTION_TYPE, new ResourceLocation(Quark.MOD_ID, "tome_enchant"), tomeEnchantType);
+		Registry.register(BuiltInRegistries.LOOT_FUNCTION_TYPE, Quark.asResource("tome_enchant"), tomeEnchantType);
 
 		overlevelTrigger = event.getAdvancementModifierRegistry().registerManualTrigger("overlevel");
 		instamineDeepslateTrigger = event.getAdvancementModifierRegistry().registerManualTrigger("instamine_deepslate");
@@ -164,7 +164,7 @@ public class AncientTomesModule extends ZetaModule {
 			String[] split = table.split(",");
 			if(split.length == 2) {
 				int weight;
-				ResourceLocation loc = new ResourceLocation(split[0]);
+				ResourceLocation loc = ResourceLocation.parse(split[0]);
 				try {
 					weight = Integer.parseInt(split[1]);
 				} catch (NumberFormatException e) {
@@ -359,7 +359,7 @@ public class AncientTomesModule extends ZetaModule {
 		return false;
 	}
 
-	private static final ResourceLocation OVERLEVEL_COLOR_HANDLER = new ResourceLocation(Quark.MOD_ID, "overlevel_rune");
+	private static final ResourceLocation OVERLEVEL_COLOR_HANDLER = Quark.asResource("overlevel_rune");
 
 	@PlayEvent
 	public void attachRuneCapability(ZAttachCapabilities.ItemStackCaps event) {
@@ -422,7 +422,7 @@ public class AncientTomesModule extends ZetaModule {
 	public static void initializeEnchantmentList(Iterable<String> enchantNames, List<Enchantment> enchants) {
 		enchants.clear();
 		for(String s : enchantNames) {
-			Enchantment enchant = BuiltInRegistries.ENCHANTMENT.get(new ResourceLocation(s));
+			Enchantment enchant = BuiltInRegistries.ENCHANTMENT.get(ResourceLocation.parse(s));
 			if(enchant != null && !EnchantmentsBegoneModule.shouldBegone(enchant))
 				enchants.add(enchant);
 		}

--- a/src/main/java/org/violetmoon/quark/content/tools/module/BeaconRedirectionModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/module/BeaconRedirectionModule.java
@@ -3,6 +3,7 @@ package org.violetmoon.quark.content.tools.module;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
@@ -41,7 +42,7 @@ import java.util.HashSet;
 @ZetaLoadModule(category = "tools")
 public class BeaconRedirectionModule extends ZetaModule {
 
-	private static final TagKey<Block> BEACON_TRANSPARENT = BlockTags.create(new ResourceLocation("quark:beacon_transparent"));
+	private static final TagKey<Block> BEACON_TRANSPARENT = Quark.asTagKey(Registries.BLOCK,"beacon_transparent");
 
 	@Config
 	public static int horizontalMoveLimit = 64;

--- a/src/main/java/org/violetmoon/quark/content/tools/module/ParrotEggsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/module/ParrotEggsModule.java
@@ -57,7 +57,7 @@ import java.util.UUID;
 @ZetaLoadModule(category = "tools")
 public class ParrotEggsModule extends ZetaModule {
 
-	private static final ResourceLocation KOTO = new ResourceLocation("quark", "textures/model/entity/variants/kotobirb.png");
+	private static final ResourceLocation KOTO = Quark.asResource("textures/model/entity/variants/kotobirb.png");
 	private static final String EGG_TIMER = "quark:parrot_egg_timer";
 
 	public static EntityType<ParrotEgg> parrotEggType;
@@ -112,7 +112,7 @@ public class ParrotEggsModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		feedTag = ItemTags.create(new ResourceLocation(Quark.MOD_ID, "parrot_feed"));
+		feedTag = Quark.asTagKey(Registries.ITEM,"parrot_feed");
 	}
 
 	@LoadEvent

--- a/src/main/java/org/violetmoon/quark/content/tools/module/PathfinderMapsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/module/PathfinderMapsModule.java
@@ -153,7 +153,7 @@ public class PathfinderMapsModule extends ZetaModule {
 		loadTradeInfo(Biomes.CHERRY_GROVE, true, 5, 20, 26, 0xE9A9E8);
 
 		inBiomeConditionType = new LootItemConditionType(new InBiomeCondition.InBiomeSerializer());
-		Registry.register(BuiltInRegistries.LOOT_CONDITION_TYPE, new ResourceLocation(Quark.MOD_ID, "in_biome"), inBiomeConditionType);
+		Registry.register(BuiltInRegistries.LOOT_CONDITION_TYPE, Quark.asResource("in_biome"), inBiomeConditionType);
 
 		pathfinderMapTrigger = event.getAdvancementModifierRegistry().registerManualTrigger("pathfinder_map_center");
 
@@ -283,7 +283,7 @@ public class PathfinderMapsModule extends ZetaModule {
 		if(tokens.length != 5 && tokens.length != 6) // Silently ignore old name format
 			throw new IllegalArgumentException("Wrong number of parameters " + tokens.length + " (expected 5)");
 
-		ResourceLocation biomeName = new ResourceLocation(tokens[0]);
+		ResourceLocation biomeName = ResourceLocation.parse(tokens[0]);
 		int level = Integer.parseInt(tokens[1]);
 		int minPrice = Integer.parseInt(tokens[2]);
 		int maxPrice = Integer.parseInt(tokens[3]);
@@ -368,7 +368,7 @@ public class PathfinderMapsModule extends ZetaModule {
 	public static class Client extends PathfinderMapsModule {
 		@LoadEvent
 		public void clientSetup(ZClientSetup e) {
-			e.enqueueWork(() -> ItemProperties.register(pathfinders_quill, new ResourceLocation("has_biome"),
+			e.enqueueWork(() -> ItemProperties.register(pathfinders_quill, Quark.asResource("has_biome"),
 					(stack, world, entity, i) -> (PathfindersQuillItem.getTargetBiome(stack) != null) ? 1 : 0));
 		}
 

--- a/src/main/java/org/violetmoon/quark/content/tools/module/PickarangModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/module/PickarangModule.java
@@ -61,9 +61,9 @@ public class PickarangModule extends ZetaModule {
     private static final List<PickarangType<?>> knownTypes = new ArrayList<>();
     private static boolean isEnabled;
 
-    public static final TagKey<Block> pickarangImmuneTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "pickarang_immune"));
+    public static final TagKey<Block> pickarangImmuneTag = Quark.asTagKey(Registries.BLOCK,"pickarang_immune");
 
-    public static final ResourceKey<DamageType> pickarangDamageType = ResourceKey.create(Registries.DAMAGE_TYPE, new ResourceLocation(Quark.MOD_ID, "pickarang"));
+    public static final ResourceKey<DamageType> pickarangDamageType = Quark.asResourceKey(Registries.DAMAGE_TYPE,"pickarang");
 
     public static ManualTrigger throwPickarangTrigger;
     public static ManualTrigger useFlamerangTrigger;

--- a/src/main/java/org/violetmoon/quark/content/tools/module/SeedPouchModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/module/SeedPouchModule.java
@@ -80,7 +80,7 @@ public class SeedPouchModule extends ZetaModule {
 		@LoadEvent
 		public void clientSetup(ZClientSetup e) {
 			e.enqueueWork(() ->
-				ItemProperties.register(seed_pouch, new ResourceLocation("pouch_items"), (ClampedItemPropertyFunction) (pouch, level, entityIn, pSeed) -> {
+				ItemProperties.register(seed_pouch, Quark.asResource("pouch_items"), (ClampedItemPropertyFunction) (pouch, level, entityIn, pSeed) -> {
 					SeedPouchItem.PouchContents contents = SeedPouchItem.getContents(pouch);
 
 					if(entityIn instanceof Player player && contents.canFit(player.containerMenu.getCarried()))

--- a/src/main/java/org/violetmoon/quark/content/tools/module/SkullPikesModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/module/SkullPikesModule.java
@@ -59,7 +59,7 @@ public class SkullPikesModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		pikeTrophiesTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "pike_trophies"));
+		pikeTrophiesTag = Quark.asResourceKey(Registries.BLOCK, "pike_trophies"));
 	}
 
 	@PlayEvent

--- a/src/main/java/org/violetmoon/quark/content/tools/module/SlimeInABucketModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/module/SlimeInABucketModule.java
@@ -13,6 +13,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.gameevent.GameEvent;
 
+import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.content.tools.item.SlimeInABucketItem;
 import org.violetmoon.zeta.client.event.load.ZClientSetup;
 import org.violetmoon.zeta.event.bus.LoadEvent;
@@ -78,7 +79,7 @@ public class SlimeInABucketModule extends ZetaModule {
 	public static class Client extends SlimeInABucketModule {
 		@LoadEvent
 		public void clientSetup(ZClientSetup event) {
-			event.enqueueWork(() -> ItemProperties.register(slime_in_a_bucket, new ResourceLocation("excited"),
+			event.enqueueWork(() -> ItemProperties.register(slime_in_a_bucket, Quark.asResource("excited"),
 					(stack, world, e, id) -> ItemNBTHelper.getBoolean(stack, SlimeInABucketItem.TAG_EXCITED, false) ? 1 : 0));
 		}
 	}

--- a/src/main/java/org/violetmoon/quark/content/tools/module/TorchArrowModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tools/module/TorchArrowModule.java
@@ -39,7 +39,7 @@ public class TorchArrowModule extends ZetaModule {
 	@Hint
 	public static Item torch_arrow;
 
-	public static final TagKey<Item> ignoreMultishot = ItemTags.create(new ResourceLocation("quark:ignore_multishot"));
+	public static final TagKey<Item> ignoreMultishot = Quark.asTagKey(Registries.ITEM,"ignore_multishot");
 
 	@LoadEvent
 	public final void register(ZRegister event) {

--- a/src/main/java/org/violetmoon/quark/content/tweaks/client/emote/CustomEmoteDescriptor.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/client/emote/CustomEmoteDescriptor.java
@@ -2,6 +2,7 @@ package org.violetmoon.quark.content.tweaks.client.emote;
 
 import net.minecraft.resources.ResourceLocation;
 
+import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.content.tweaks.module.EmotesModule;
 
 public class CustomEmoteDescriptor extends EmoteDescriptor {
@@ -11,12 +12,12 @@ public class CustomEmoteDescriptor extends EmoteDescriptor {
 	}
 
 	public static ResourceLocation getSprite(String name) {
-		ResourceLocation customRes = new ResourceLocation(EmoteHandler.CUSTOM_EMOTE_NAMESPACE, name);
+		ResourceLocation customRes = ResourceLocation.fromNamespaceAndPath(EmoteHandler.CUSTOM_EMOTE_NAMESPACE, name);
 		//if(EmotesModule.Client.resourcePack.hasResource(PackType.CLIENT_RESOURCES, customRes))
 		if(EmotesModule.Client.resourcePack.hasResource(name))
 			return customRes;
 
-		return new ResourceLocation("quark", "textures/emote/custom.png");
+		return Quark.asResource("textures/emote/custom.png");
 	}
 
 	@Override

--- a/src/main/java/org/violetmoon/quark/content/tweaks/client/emote/CustomEmoteIconResourcePack.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/client/emote/CustomEmoteIconResourcePack.java
@@ -104,9 +104,9 @@ public class CustomEmoteIconResourcePack extends AbstractPackResources {
 				if(file.isDirectory()) {
 					if(maxDepth > 0)
 						this.crawl(file, maxDepth - 1, namespace, allResources, path + file.getName() + "/", filter);
-				} else if(!file.getName().endsWith(".mcmeta") && filter.test(new ResourceLocation(namespace, path + file.getName()))) {
+				} else if(!file.getName().endsWith(".mcmeta") && filter.test(ResourceLocation.fromNamespaceAndPath(namespace, path + file.getName()))) {
 					try {
-						allResources.add(new ResourceLocation(namespace, path + file.getName()));
+						allResources.add(ResourceLocation.fromNamespaceAndPath(namespace, path + file.getName()));
 					} catch (ResourceLocationException e) {
 						Quark.LOG.error(e.getMessage());
 					}

--- a/src/main/java/org/violetmoon/quark/content/tweaks/client/emote/EmoteDescriptor.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/client/emote/EmoteDescriptor.java
@@ -4,14 +4,15 @@ import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
+import org.violetmoon.quark.base.Quark;
 
 public class EmoteDescriptor {
 
-	public static final ResourceLocation TIER_1 = new ResourceLocation("quark", "textures/emote/patreon_t1.png");
-	public static final ResourceLocation TIER_2 = new ResourceLocation("quark", "textures/emote/patreon_t2.png");
-	public static final ResourceLocation TIER_3 = new ResourceLocation("quark", "textures/emote/patreon_t3.png");
-	public static final ResourceLocation TIER_4 = new ResourceLocation("quark", "textures/emote/patreon_t4.png");
-	public static final ResourceLocation TIER_GOD = new ResourceLocation("quark", "textures/emote/patreon_t99.png");
+	public static final ResourceLocation TIER_1 = Quark.asResource("textures/emote/patreon_t1.png");
+	public static final ResourceLocation TIER_2 = Quark.asResource("textures/emote/patreon_t2.png");
+	public static final ResourceLocation TIER_3 = Quark.asResource("textures/emote/patreon_t3.png");
+	public static final ResourceLocation TIER_4 = Quark.asResource("textures/emote/patreon_t4.png");
+	public static final ResourceLocation TIER_GOD = Quark.asResource("textures/emote/patreon_t99.png");
 
 	public final Class<? extends EmoteBase> clazz;
 	public final int index;
@@ -23,7 +24,7 @@ public class EmoteDescriptor {
 	private int tier;
 
 	public EmoteDescriptor(Class<? extends EmoteBase> clazz, String name, String regName, int index) {
-		this(clazz, name, regName, index, new ResourceLocation("quark", "textures/emote/" + name + ".png"), new EmoteTemplate(name + ".emote"));
+		this(clazz, name, regName, index, Quark.asResource("textures/emote/" + name + ".png"), new EmoteTemplate(name + ".emote"));
 	}
 
 	public EmoteDescriptor(Class<? extends EmoteBase> clazz, String name, String regName, int index, ResourceLocation texture, EmoteTemplate template) {

--- a/src/main/java/org/violetmoon/quark/content/tweaks/client/emote/EmoteTemplate.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/client/emote/EmoteTemplate.java
@@ -386,7 +386,7 @@ public class EmoteTemplate {
 				throw new IllegalArgumentException("Illegal number in function sound", ex);
 			}
 
-			ResourceLocation soundEvent = new ResourceLocation(type);
+			ResourceLocation soundEvent = ResourceLocation.parse(type);
 
 			List<BaseTween<?>> children = timeline.getChildren();
 

--- a/src/main/java/org/violetmoon/quark/content/tweaks/module/CompassesWorkEverywhereModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/module/CompassesWorkEverywhereModule.java
@@ -13,6 +13,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.dimension.LevelStem;
 
+import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.content.tweaks.client.item.ClockTimePropertyFunction;
 import org.violetmoon.quark.content.tweaks.client.item.CompassAnglePropertyFunction;
 import org.violetmoon.zeta.client.event.load.ZClientSetup;
@@ -131,10 +132,10 @@ public class CompassesWorkEverywhereModule extends ZetaModule {
 					return;
 
 				if(enableCompassNerf || enableNether || enableEnd)
-					ItemProperties.register(Items.COMPASS, new ResourceLocation("angle"), new CompassAnglePropertyFunction());
+					ItemProperties.register(Items.COMPASS, Quark.asResource("angle"), new CompassAnglePropertyFunction());
 
 				if(enableClockNerf)
-					ItemProperties.register(Items.CLOCK, new ResourceLocation("time"), new ClockTimePropertyFunction());
+					ItemProperties.register(Items.CLOCK, Quark.asResource("time"), new ClockTimePropertyFunction());
 			});
 		}
 

--- a/src/main/java/org/violetmoon/quark/content/tweaks/module/DiamondRepairModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/module/DiamondRepairModule.java
@@ -63,13 +63,13 @@ public class DiamondRepairModule extends ZetaModule {
 		for(String s : repairChangesList) {
 			String[] toks = s.split("=");
 			if(toks.length == 2) {
-				ResourceLocation itemRes = new ResourceLocation(toks[0]);
+				ResourceLocation itemRes = ResourceLocation.parse(toks[0]);
 
 				if(BuiltInRegistries.ITEM.containsKey(itemRes)) {
 					String repairItems = toks[1];
 					String[] repairToks = repairItems.split(",");
 					for(String repairTok : repairToks) {
-						ResourceLocation repairItemRes = new ResourceLocation(repairTok);
+						ResourceLocation repairItemRes = ResourceLocation.parse(repairTok);
 
 						if(BuiltInRegistries.ITEM.containsKey(repairItemRes)) {
 							Item item = BuiltInRegistries.ITEM.get(itemRes);

--- a/src/main/java/org/violetmoon/quark/content/tweaks/module/DoubleDoorOpeningModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/module/DoubleDoorOpeningModule.java
@@ -5,6 +5,7 @@ import com.google.common.base.Predicates;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.ItemTags;
@@ -59,7 +60,7 @@ public class DoubleDoorOpeningModule extends ZetaModule {
 
 	@LoadEvent
 	public void setup(ZCommonSetup e) {
-		nonDoubleDoorTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "non_double_door"));
+		nonDoubleDoorTag = Quark.asTagKey(Registries.BLOCK,"non_double_door");
 	}
 
 	public boolean openBlock(Level world, Player player, BlockPos pos) {

--- a/src/main/java/org/violetmoon/quark/content/tweaks/module/EnhancedLaddersModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/module/EnhancedLaddersModule.java
@@ -4,6 +4,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.Input;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
@@ -71,8 +72,8 @@ public class EnhancedLaddersModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		laddersTag = ItemTags.create(new ResourceLocation(Quark.MOD_ID, "ladders"));
-		laddersBlockTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "ladders"));
+		laddersTag = Quark.asTagKey(Registries.ITEM,"ladders");
+		laddersBlockTag = Quark.asTagKey(Registries.BLOCK,"ladders");
 	}
 
 	@LoadEvent

--- a/src/main/java/org/violetmoon/quark/content/tweaks/module/GlassShardModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/module/GlassShardModule.java
@@ -3,6 +3,7 @@ package org.violetmoon.quark.content.tweaks.module;
 import java.util.EnumMap;
 import java.util.Map;
 
+import net.minecraft.core.registries.Registries;
 import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.content.experimental.module.VariantSelectorModule;
 import org.violetmoon.quark.content.tweaks.block.DirtyGlassBlock;
@@ -63,6 +64,6 @@ public class GlassShardModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		shardTag = ItemTags.create(new ResourceLocation(Quark.MOD_ID, "shards"));
+		shardTag = Quark.asTagKey(Registries.ITEM,"shards");
 	}
 }

--- a/src/main/java/org/violetmoon/quark/content/tweaks/module/HoeHarvestingModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/module/HoeHarvestingModule.java
@@ -1,5 +1,6 @@
 package org.violetmoon.quark.content.tweaks.module;
 
+import net.minecraft.core.registries.Registries;
 import org.violetmoon.quark.base.Quark;
 import org.violetmoon.zeta.config.Config;
 import org.violetmoon.zeta.event.bus.LoadEvent;
@@ -76,7 +77,7 @@ public class HoeHarvestingModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		bigHarvestingHoesTag = ItemTags.create(new ResourceLocation(Quark.MOD_ID, "big_harvesting_hoes"));
+		bigHarvestingHoesTag = Quark.asTagKey(Registries.ITEM, "big_harvesting_hoes");
 	}
 
 	@PlayEvent

--- a/src/main/java/org/violetmoon/quark/content/tweaks/module/NoDurabilityOnCosmeticsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/module/NoDurabilityOnCosmeticsModule.java
@@ -1,5 +1,6 @@
 package org.violetmoon.quark.content.tweaks.module;
 
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
@@ -25,7 +26,7 @@ public class NoDurabilityOnCosmeticsModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		cosmeticTag = ItemTags.create(new ResourceLocation(Quark.MOD_ID, "cosmetic_anvil_items"));
+		cosmeticTag = Quark.asTagKey(Registries.ITEM,"cosmetic_anvil_items"));
 	}
 
 	@PlayEvent

--- a/src/main/java/org/violetmoon/quark/content/tweaks/module/ReacharoundPlacingModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/module/ReacharoundPlacingModule.java
@@ -11,6 +11,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundSource;
@@ -48,8 +49,8 @@ import java.util.List;
 @ZetaLoadModule(category = "tweaks")
 public class ReacharoundPlacingModule extends ZetaModule {
 
-	public static final ResourceLocation OVERLAY_HORIZONTAL = new ResourceLocation(Quark.MOD_ID, "textures/gui/reacharound_overlay_horizontal.png");
-	public static final ResourceLocation OVERLAY_VERTICAL = new ResourceLocation(Quark.MOD_ID, "textures/gui/reacharound_overlay_vertical.png");
+	public static final ResourceLocation OVERLAY_HORIZONTAL = Quark.asResource("textures/gui/reacharound_overlay_horizontal.png");
+	public static final ResourceLocation OVERLAY_VERTICAL = Quark.asResource("textures/gui/reacharound_overlay_vertical.png");
 
 	@Config
 	@Config.Min(0)
@@ -69,7 +70,7 @@ public class ReacharoundPlacingModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		reacharoundTag = ItemTags.create(new ResourceLocation(Quark.MOD_ID, "reacharound_able"));
+		reacharoundTag = Quark.asTagKey(Registries.ITEM, "reacharound_able");
 	}
 
 	@PlayEvent

--- a/src/main/java/org/violetmoon/quark/content/tweaks/module/SimpleHarvestModule.java
+++ b/src/main/java/org/violetmoon/quark/content/tweaks/module/SimpleHarvestModule.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import net.minecraft.core.registries.Registries;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.fml.loading.FMLLoader;
@@ -116,7 +117,7 @@ public class SimpleHarvestModule extends ZetaModule {
 
 	@LoadEvent
 	public void setup(ZCommonSetup event) {
-		simpleHarvestBlacklistedTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "simple_harvest_blacklisted"));
+		simpleHarvestBlacklistedTag = Quark.asTagKey(Registries.BLOCK,"simple_harvest_blacklisted");
 	}
 
 	@LoadEvent
@@ -153,7 +154,7 @@ public class SimpleHarvestModule extends ZetaModule {
 		}
 
 		for(String blockName : rightClickableBlocks) {
-			Block block = BuiltInRegistries.BLOCK.get(new ResourceLocation(blockName));
+			Block block = BuiltInRegistries.BLOCK.get(ResourceLocation.parse(blockName));
 			if(block != Blocks.AIR)
 				rightClickCrops.add(block);
 		}

--- a/src/main/java/org/violetmoon/quark/content/world/gen/ObsidianSpikeGenerator.java
+++ b/src/main/java/org/violetmoon/quark/content/world/gen/ObsidianSpikeGenerator.java
@@ -105,7 +105,7 @@ public class ObsidianSpikeGenerator extends Generator {
 
 				placePos = placePos.below();
 				world.setBlock(placePos, Blocks.CHEST.defaultBlockState(), 0);
-				RandomizableContainerBlockEntity.setLootTable(world, rand, placePos, new ResourceLocation("minecraft", "chests/nether_bridge"));
+				RandomizableContainerBlockEntity.setLootTable(world, rand, placePos, ResourceLocation.withDefaultNamespace("chests/nether_bridge"));
 			}
 		}
 	}

--- a/src/main/java/org/violetmoon/quark/content/world/module/BigStoneClustersModule.java
+++ b/src/main/java/org/violetmoon/quark/content/world/module/BigStoneClustersModule.java
@@ -117,7 +117,7 @@ public class BigStoneClustersModule extends ZetaModule {
 			}
 
 			String dimFinal = dimension;
-			BuiltInRegistries.BLOCK.getOptional(new ResourceLocation(bname)).ifPresent(blockObj -> {
+			BuiltInRegistries.BLOCK.getOptional(ResourceLocation.parse(bname)).ifPresent(blockObj -> {
 				if(blockObj != Blocks.AIR) {
 					if(dimFinal == null)
 						blockReplacePredicate = blockReplacePredicate.or((w, b) -> blockObj == b);

--- a/src/main/java/org/violetmoon/quark/content/world/module/BlossomTreesModule.java
+++ b/src/main/java/org/violetmoon/quark/content/world/module/BlossomTreesModule.java
@@ -119,7 +119,7 @@ public class BlossomTreesModule extends ZetaModule {
 	}
 
 	private static ResourceKey<ConfiguredFeature<?, ?>> registerKey(String name) {
-		return ResourceKey.create(Registries.CONFIGURED_FEATURE, Quark.asResource(name));
+		return Quark.asResourceKey(Registries.CONFIGURED_FEATURE, name);
 	}
 
 }

--- a/src/main/java/org/violetmoon/quark/content/world/module/CorundumModule.java
+++ b/src/main/java/org/violetmoon/quark/content/world/module/CorundumModule.java
@@ -2,6 +2,7 @@ package org.violetmoon.quark.content.world.module;
 
 import java.util.List;
 
+import net.minecraft.core.registries.Registries;
 import org.apache.commons.lang3.tuple.Pair;
 import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.base.util.CorundumColor;
@@ -91,7 +92,7 @@ public class CorundumModule extends ZetaModule {
 	public static List<CorundumBlock> crystals = Lists.newArrayList();
 	public static List<CorundumClusterBlock> clusters = Lists.newArrayList();
 	@Hint
-	public static final TagKey<Block> corundumTag = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "corundum"));
+	public static final TagKey<Block> corundumTag = Quark.asTagKey(Registries.BLOCK,"corundum");
 
 	@LoadEvent
 	public final void register(ZRegister event) {

--- a/src/main/java/org/violetmoon/quark/content/world/module/FairyRingsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/world/module/FairyRingsModule.java
@@ -45,7 +45,7 @@ public class FairyRingsModule extends ZetaModule {
 	public final void configChanged(ZConfigChanged event) {
 		ores.clear();
 		for(String s : oresRaw) {
-			Block b = BuiltInRegistries.BLOCK.get(new ResourceLocation(s));
+			Block b = BuiltInRegistries.BLOCK.get(ResourceLocation.parse(s));
 			if(b != Blocks.AIR) {
 				ores.add(b.defaultBlockState());
 			} else {

--- a/src/main/java/org/violetmoon/quark/content/world/module/FallenLogsModule.java
+++ b/src/main/java/org/violetmoon/quark/content/world/module/FallenLogsModule.java
@@ -61,8 +61,8 @@ public class FallenLogsModule extends ZetaModule {
 
 	@LoadEvent
 	public final void setup(ZCommonSetup event) {
-		reducedLogsTag = TagKey.create(Registries.BIOME, new ResourceLocation(Quark.MOD_ID, "has_lower_fallen_tree_density"));
-		canSpawnOnTag = TagKey.create(Registries.BLOCK, new ResourceLocation(Quark.MOD_ID, "fallen_log_can_spawn_on"));
+		reducedLogsTag = Quark.asTagKey(Registries.BIOME, "has_lower_fallen_tree_density");
+		canSpawnOnTag = Quark.asTagKey(Registries.BLOCK, "fallen_log_can_spawn_on");
 		WorldGenHandler.addGenerator(this, new FallenLogGenerator(dimensions), Decoration.TOP_LAYER_MODIFICATION, QuarkWorldGenWeights.FALLEN_LOGS);
 	}
 	
@@ -75,8 +75,8 @@ public class FallenLogsModule extends ZetaModule {
 			String k = toks[0];
 			String v = toks[1];
 			
-			TagKey<Biome> tag = TagKey.create(Registries.BIOME, new ResourceLocation(k));
-			Block block = BuiltInRegistries.BLOCK.get(new ResourceLocation(v));
+			TagKey<Biome> tag = Quark.asTagKey(Registries.BIOME, (k));
+			Block block = BuiltInRegistries.BLOCK.get(ResourceLocation.parse(v));
 			
 			if(block == null)
 				throw new IllegalArgumentException("Block " + v + " doesn't exist");

--- a/src/main/java/org/violetmoon/quark/content/world/module/GlimmeringWealdModule.java
+++ b/src/main/java/org/violetmoon/quark/content/world/module/GlimmeringWealdModule.java
@@ -37,8 +37,8 @@ import org.violetmoon.zeta.util.Hint;
 @ZetaLoadModule(category = "world")
 public class GlimmeringWealdModule extends ZetaModule {
 
-    public static final ResourceLocation BIOME_NAME = new ResourceLocation(Quark.MOD_ID, "glimmering_weald");
-    public static final ResourceKey<Biome> BIOME_KEY = ResourceKey.create(Registries.BIOME, BIOME_NAME);
+    public static final ResourceLocation BIOME_NAME = Quark.asResource("glimmering_weald");
+    public static final ResourceKey<Biome> BIOME_KEY = Quark.asResourceKey(Registries.BIOME, "glimmering_weald");
 
     public static GlowShroomsFeature glow_shrooms_feature;
     public static GlowExtrasFeature glow_shrooms_extra_feature;
@@ -116,7 +116,7 @@ public class GlimmeringWealdModule extends ZetaModule {
 
     @LoadEvent
     public void setup(ZCommonSetup e) {
-        glowShroomFeedablesTag = ItemTags.create(new ResourceLocation(Quark.MOD_ID, "glow_shroom_feedables"));
+        glowShroomFeedablesTag = Quark.asTagKey(Registries.ITEM,"glow_shroom_feedables");
 
         e.enqueueWork(() -> {
             ComposterBlock.COMPOSTABLES.put(glow_shroom.asItem(), 0.65F);

--- a/src/main/java/org/violetmoon/quark/content/world/module/MonsterBoxModule.java
+++ b/src/main/java/org/violetmoon/quark/content/world/module/MonsterBoxModule.java
@@ -39,8 +39,8 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 public class MonsterBoxModule extends ZetaModule {
 
 	public static final String TAG_MONSTER_BOX_SPAWNED = "quark:monster_box_spawned";
-	public static final ResourceLocation MONSTER_BOX_LOOT_TABLE = new ResourceLocation(Quark.MOD_ID, "misc/monster_box");
-	public static final ResourceLocation MONSTER_BOX_SPAWNS_LOOT_TABLE = new ResourceLocation(Quark.MOD_ID, "misc/monster_box_spawns");
+	public static final ResourceLocation MONSTER_BOX_LOOT_TABLE = Quark.asResource("misc/monster_box");
+	public static final ResourceLocation MONSTER_BOX_SPAWNS_LOOT_TABLE = Quark.asResource("misc/monster_box_spawns");
 
 	public static BlockEntityType<MonsterBoxBlockEntity> blockEntityType;
 

--- a/src/main/java/org/violetmoon/quark/content/world/undergroundstyle/base/UndergroundStyle.java
+++ b/src/main/java/org/violetmoon/quark/content/world/undergroundstyle/base/UndergroundStyle.java
@@ -1,5 +1,6 @@
 package org.violetmoon.quark.content.world.undergroundstyle.base;
 
+import net.minecraft.core.registries.Registries;
 import org.violetmoon.quark.base.Quark;
 import org.violetmoon.quark.content.world.undergroundstyle.base.UndergroundStyleGenerator.Context;
 import org.violetmoon.zeta.util.MiscUtil;
@@ -15,7 +16,7 @@ import net.minecraft.world.level.block.state.BlockState;
 
 public abstract class UndergroundStyle {
 
-	private static final TagKey<Block> UNDERGROUND_BIOME_REPLACEABLE = BlockTags.create(new ResourceLocation(Quark.MOD_ID, "underground_biome_replaceable"));
+	private static final TagKey<Block> UNDERGROUND_BIOME_REPLACEABLE = Quark.asTagKey(Registries.BLOCK, "underground_biome_replaceable"));
 
 	public boolean canReplace(BlockState state) {
 		return state.canBeReplaced() || state.is(UNDERGROUND_BIOME_REPLACEABLE);

--- a/src/main/java/org/violetmoon/quark/integration/jei/InfluenceCategory.java
+++ b/src/main/java/org/violetmoon/quark/integration/jei/InfluenceCategory.java
@@ -21,9 +21,9 @@ import org.violetmoon.quark.base.Quark;
 
 public class InfluenceCategory implements IRecipeCategory<InfluenceEntry> {
 
-	public static final ResourceLocation UID = new ResourceLocation(Quark.MOD_ID, "influence");
+	public static final ResourceLocation UID = Quark.asResource("influence");
 
-	public static final ResourceLocation TEXTURE = new ResourceLocation(Quark.MOD_ID, "textures/gui/jei_influence.png");
+	public static final ResourceLocation TEXTURE = Quark.asResource("textures/gui/jei_influence.png");
 
 	private final IDrawable icon;
 	private final IDrawableStatic background;

--- a/src/main/java/org/violetmoon/quark/integration/jei/QuarkJeiPlugin.java
+++ b/src/main/java/org/violetmoon/quark/integration/jei/QuarkJeiPlugin.java
@@ -40,7 +40,7 @@ import java.util.stream.Stream;
 
 @JeiPlugin
 public class QuarkJeiPlugin implements IModPlugin {
-    private static final ResourceLocation UID = new ResourceLocation(Quark.MOD_ID, Quark.MOD_ID);
+    private static final ResourceLocation UID = Quark.asResource(Quark.MOD_ID);
 
     public static final RecipeType<InfluenceEntry> INFLUENCING =
             RecipeType.create(Quark.MOD_ID, "influence", InfluenceEntry.class);

--- a/src/main/java/org/violetmoon/quark/integration/lootr/client/LootrVariantChestRenderer.java
+++ b/src/main/java/org/violetmoon/quark/integration/lootr/client/LootrVariantChestRenderer.java
@@ -63,6 +63,6 @@ public class LootrVariantChestRenderer<T extends LootrVariantChestBlockEntity> e
 				tex.append("lootr_normal");
 		}
 
-		return new Material(Sheets.CHEST_SHEET, new ResourceLocation(Quark.MOD_ID, tex.toString()));
+		return new Material(Sheets.CHEST_SHEET, Quark.asResource(tex.toString()));
 	}
 }


### PR DESCRIPTION
ResourceLocation/Key chore
- new ResourceLocation(Quark.MOD_ID -> Quark.asResource(
- new ResourceLocation(string) -> ResourceLocation.Parse(, EXCEPT when it's a vanilla asset (in which case ResourceLocation.withDefaultNamespace is used) and EXCEPT in client model ItemProperties code, but the latter may need a second pass because I'm not familiar with the convention
- getDefaultLootTable now returns ResourceKey<LootTable>
- new TagKey( -> Quark.asTagKey(, this new method technically makes modules classload Registries but that is probably fine :clueless:

I started this while BrokenK3yboard was working hence the merge conflict