### PR TITLE
Fix Azalea boats missing Minecraft boat and chest boat tags.

### DIFF
--- a/src/main/resources/data/minecraft/tags/items/boats.json
+++ b/src/main/resources/data/minecraft/tags/items/boats.json
@@ -1,6 +1,7 @@
 {
   "values": [
     "quark:blossom_boat",
-    "quark:ancient_boat"
+    "quark:ancient_boat",
+    "quark:azalea_boat"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/items/chest_boats.json
+++ b/src/main/resources/data/minecraft/tags/items/chest_boats.json
@@ -2,6 +2,6 @@
   "values": [
     "quark:blossom_chest_boat",
     "quark:ancient_chest_boat",
-    "quark:azalea_chest_boat",
+    "quark:azalea_chest_boat"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/items/chest_boats.json
+++ b/src/main/resources/data/minecraft/tags/items/chest_boats.json
@@ -1,6 +1,7 @@
 {
   "values": [
     "quark:blossom_chest_boat",
-    "quark:ancient_chest_boat"
+    "quark:ancient_chest_boat",
+    "quark:azalea_chest_boat",
   ]
 }


### PR DESCRIPTION
Azalea Boats and Chest Boats are missing the Minecraft boat tags.