### PR TITLE
Rename Flamarang to Flamerang

### DIFF
--- a/src/main/resources/assets/quark/lang/en_us.json
+++ b/src/main/resources/assets/quark/lang/en_us.json
@@ -520,7 +520,7 @@
 	"item.quark.backpack": "Backpack",
 	"item.quark.ravager_hide": "Ravager Hide",
 	"item.quark.bottled_cloud": "Cloud in a Bottle",
-	"item.quark.flamerang": "Flamarang",
+	"item.quark.flamerang": "Flamerang",
 	"item.quark.seed_pouch": "Seed Pouch",
 	"item.quark.forgotten_hat": "Forgotten Hat",
 	"item.quark.soul_bead": "Soul Bead",


### PR DESCRIPTION
Everywhere else it's referred to as a Flamerang, and it sounds better IMO