### PR TITLE
Show unstackable blocks in usage ticker

### DIFF
--- a/src/main/java/org/violetmoon/quark/content/client/module/UsageTickerModule.java
+++ b/src/main/java/org/violetmoon/quark/content/client/module/UsageTickerModule.java
@@ -10,6 +10,7 @@ import net.minecraft.world.entity.EquipmentSlot.Type;
 import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.ProjectileWeaponItem;
 import net.minecraft.world.item.enchantment.Enchantments;
@@ -199,7 +200,7 @@ public class UsageTickerModule extends ZetaModule {
 				}
 
 				if(!logicLock) {
-					if(!stack.isStackable() && slot.getType() == Type.HAND)
+					if(!stack.isStackable() && !(stack.getItem() instanceof BlockItem) && slot.getType() == Type.HAND)
 						returnStack = ItemStack.EMPTY;
 					else if(verifySize && stack.isStackable() && count == stack.getCount())
 						returnStack = ItemStack.EMPTY;
@@ -214,7 +215,7 @@ public class UsageTickerModule extends ZetaModule {
 			public int getStackCount(Player player, ItemStack displayStack, ItemStack original, boolean renderPass) {
 				int val = 1;
 
-				if(displayStack.isStackable()) {
+				if(displayStack.isStackable() || (displayStack.getItem() instanceof BlockItem)) {
 					Predicate<ItemStack> predicate = (stackAt) -> ItemStack.isSameItemSameTags(stackAt, displayStack);
 
 					int total = 0;


### PR DESCRIPTION
This PR modifies the default usage ticker behavior so it supports showing unstackable blocks by way of checking if the item extends `BlockItem`. This won't cover all blocks but it's a good start. Maybe it'd be worth considering tracking every item regardless of stackability, but I didn't want to stray too far from the current implementation.

### Motivation

In Vanilla, this could be useful for keeping track of how many beds are remaining in one's inventory when using them to hunt for ancient debris. Though my main use-case is for my own modpack where most blocks have a stack size of 1, causing them to (unfairly) fall through the current usage ticker checks.