### PR TITLE
Made the Crafter block more accurate

### DIFF
--- a/src/main/java/org/violetmoon/quark/content/automation/block/CrafterBlock.java
+++ b/src/main/java/org/violetmoon/quark/content/automation/block/CrafterBlock.java
@@ -136,7 +136,7 @@ public class CrafterBlock extends ZetaBlock implements EntityBlock {
 
 	@Override
 	public BlockState getStateForPlacement(BlockPlaceContext ctx) {
-		return this.defaultBlockState().setValue(FACING, ctx.getHorizontalDirection().getOpposite());
+		return this.defaultBlockState().setValue(FACING, ctx.getNearestLookingDirection().getOpposite());
 	}
 
 	@Override


### PR DESCRIPTION
Made the Crafter block more accurate to the 1.21 Crafter by changing placement direction from horizontal direction to nearest looking direction.

I tested the changes in a test instance and it works just like it does in 1.21.