### PR TITLE
Fix quark boats flipping upside down on bubble columns.

### DIFF
--- a/src/main/java/org/violetmoon/quark/base/client/render/QuarkBoatRenderer.java
+++ b/src/main/java/org/violetmoon/quark/base/client/render/QuarkBoatRenderer.java
@@ -69,7 +69,8 @@ public class QuarkBoatRenderer extends EntityRenderer<Boat> {
 
 		float f2 = boat.getBubbleAngle(partialTicks);
 		if(!Mth.equal(f2, 0.0F)) {
-			matrix.mulPose(new Quaternionf(1.0F, 0.0F, 1.0F, boat.getBubbleAngle(partialTicks) * ((float) Math.PI / 180F)));
+			matrix.mulPose((new Quaternionf()).setAngleAxis(boat.getBubbleAngle(partialTicks) * 0.017453292F, 1.0F,
+					0.0F, 1.0F));
 		}
 
 		BoatModelTuple tuple = getModelWithLocation(boat);


### PR DESCRIPTION
Fixes #5225

The transformation when `bubbleAngle != 0` was subtly different than the one for vanilla boats. This makes the code the same as vanilla boats.