### PR TITLE
Added config option to totem of holding to drop all items when punched.

### DIFF
--- a/src/main/java/org/violetmoon/quark/addons/oddities/entity/TotemOfHoldingEntity.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/entity/TotemOfHoldingEntity.java
@@ -87,7 +87,9 @@ public class TotemOfHoldingEntity extends Entity {
 		if (level() instanceof ServerLevel serverLevel && entity instanceof Player player) {
 			if (!TotemOfHoldingModule.allowAnyoneToCollect && !player.hasInfiniteMaterials() && entity != getOwnerEntity()) return false;
 
-			int drops = Math.min(storedItems.size(), 3 + level().random.nextInt(4));
+            int drops = storedItems.size();
+			if(!TotemOfHoldingModule.dropAllItemsOnHit)
+				drops = Math.min(storedItems.size(), 3 + level().random.nextInt(4));
 
 			for (int i = 0; i < drops; i++) {
 				ItemStack stack = storedItems.removeFirst();

--- a/src/main/java/org/violetmoon/quark/addons/oddities/module/TotemOfHoldingModule.java
+++ b/src/main/java/org/violetmoon/quark/addons/oddities/module/TotemOfHoldingModule.java
@@ -53,6 +53,9 @@ public class TotemOfHoldingModule extends ZetaModule {
 	@Config(description = "Set this to false to only allow the owner of a totem to collect its items rather than any player")
 	public static boolean allowAnyoneToCollect = true;
 
+	@Config(description = "Set this to true to drop everything when punched")
+	public static boolean dropAllItemsOnHit = false;
+
 	@LoadEvent
 	public final void register(ZRegister event) {
 		totemType = EntityType.Builder.of(TotemOfHoldingEntity::new, MobCategory.MISC)


### PR DESCRIPTION
I made this PR because it was very frustrating to have to punch the totem of holding 4 or 5 times just to get all my items back.

This serves to fix that in a very simple way. It adds one config option to allow the totem of holding to drop all items when hit once.